### PR TITLE
Add Holtek Venus MMO (04D9:FC55) device support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ __pycache__/
 *.bak
 CLAUDE.md
 AGENTS.md
+
+# makepkg build artifacts
+pkg/
+src/
+*.pkg.tar*

--- a/device_driver.py
+++ b/device_driver.py
@@ -1,0 +1,36 @@
+"""Device detection and factory layer.
+
+Provides a thin abstraction to detect which device variant is connected
+and create the appropriate device/protocol objects.
+"""
+from __future__ import annotations
+
+import venus_protocol as vp
+import holtek_protocol as hp
+
+
+def detect_device_type(device_info: vp.DeviceInfo) -> str:
+    """Determine device type from VID/PID.
+
+    Returns 'holtek' for 04D9:FC55, 'venus_pro' otherwise.
+    """
+    if device_info.vendor_id == hp.VENDOR_ID and device_info.product_id == hp.PRODUCT_ID:
+        return 'holtek'
+    return 'venus_pro'
+
+
+def get_button_profiles(device_type: str) -> dict:
+    """Return the appropriate BUTTON_PROFILES dict for the device type."""
+    if device_type == 'holtek':
+        return hp.BUTTON_PROFILES
+    return vp.BUTTON_PROFILES
+
+
+def create_device(device_type: str, path: str):
+    """Factory: create the right device class for the variant.
+
+    Returns HoltekDevice or VenusDevice.
+    """
+    if device_type == 'holtek':
+        return hp.HoltekDevice(path)
+    return vp.VenusDevice(path)

--- a/diag_buttons.py
+++ b/diag_buttons.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Diagnostic: dump all 20 button entries from the Holtek device.
+
+Run with: python3 diag_buttons.py
+
+Shows the raw 4-byte entry at each memory index so we can verify
+which physical button corresponds to which firmware slot.
+"""
+import holtek_protocol as hp
+
+BUTTON_TYPE_NAMES = {
+    0x00: "Disabled",
+    0x81: "LMB",
+    0x82: "RMB",
+    0x83: "MMB",
+    0x84: "Back",
+    0x85: "Forward",
+    0x8A: "DPI Up",
+    0x8C: "DPI Down",
+    0x8D: "Profile Switch",
+    0x90: "Keyboard Key",
+}
+
+# HID key names for common scancodes
+HID_KEY_NAMES = {
+    0x04: "A", 0x05: "B", 0x06: "C", 0x07: "D", 0x08: "E", 0x09: "F",
+    0x0A: "G", 0x0B: "H", 0x0C: "I", 0x0D: "J", 0x0E: "K", 0x0F: "L",
+    0x10: "M", 0x11: "N", 0x12: "O", 0x13: "P", 0x14: "Q", 0x15: "R",
+    0x16: "S", 0x17: "T", 0x18: "U", 0x19: "V", 0x1A: "W", 0x1B: "X",
+    0x1C: "Y", 0x1D: "Z",
+    0x1E: "1", 0x1F: "2", 0x20: "3", 0x21: "4", 0x22: "5",
+    0x23: "6", 0x24: "7", 0x25: "8", 0x26: "9", 0x27: "0",
+    0x28: "Enter", 0x29: "Escape", 0x2A: "Backspace", 0x2B: "Tab",
+    0x2C: "Space",
+    0x3A: "F1", 0x3B: "F2", 0x3C: "F3", 0x3D: "F4", 0x3E: "F5",
+    0x3F: "F6", 0x40: "F7", 0x41: "F8", 0x42: "F9", 0x43: "F10",
+    0x44: "F11", 0x45: "F12",
+    0x56: "Numpad -", 0x57: "Numpad +",
+    0x59: "Numpad 1", 0x5A: "Numpad 2", 0x5B: "Numpad 3",
+    0x5C: "Numpad 4", 0x5D: "Numpad 5", 0x5E: "Numpad 6",
+    0x5F: "Numpad 7", 0x60: "Numpad 8", 0x61: "Numpad 9",
+    0x62: "Numpad 0",
+}
+
+def describe_entry(raw: bytes) -> str:
+    """Human-readable description of a 4-byte button entry."""
+    type_lo, type_hi, code_lo, code_hi = raw
+    type_name = BUTTON_TYPE_NAMES.get(type_lo, f"0x{type_lo:02X}")
+    if type_lo == 0x90:  # Keyboard
+        key_name = HID_KEY_NAMES.get(code_lo, f"0x{code_lo:02X}")
+        return f"Keyboard: {key_name} (HID 0x{code_lo:02X})"
+    elif type_lo in (0x81, 0x82, 0x83, 0x84, 0x85, 0x8A, 0x8C, 0x8D):
+        return type_name
+    elif type_lo == 0x00:
+        return "Disabled"
+    else:
+        return f"type=0x{type_lo:02X} hi=0x{type_hi:02X} code=0x{code_lo:02X} code_hi=0x{code_hi:02X}"
+
+
+def main():
+    import venus_protocol as vp
+
+    infos = vp.list_devices()
+    holtek = [i for i in infos if i.vendor_id == 0x04D9 and i.product_id == 0xFC55]
+    if not holtek:
+        print("No Holtek device found!")
+        return
+
+    info = holtek[0]
+    print(f"Device: {info.product} at {info.path}")
+    print()
+
+    dev = hp.HoltekDevice(info.path)
+    dev.open()
+
+    try:
+        profile = dev.read_active_profile()
+        print(f"Active profile: {profile}")
+        print()
+
+        for prof in range(5):
+            btn_base = hp.ADDR_BUTTONS_PROFILE[prof]
+            btn_end = btn_base + 2 + 20 * 4
+
+            # Read button data
+            button_data = bytearray()
+            for addr in range(btn_base, btn_end, 8):
+                chunk_len = min(8, btn_end - addr)
+                chunk = dev.read_memory(addr, chunk_len)
+                button_data.extend(chunk)
+
+            count = button_data[0] | (button_data[1] << 8)
+            print(f"=== Profile {prof} (base=0x{btn_base:04X}, count={count}) ===")
+
+            # Current BUTTON_PROFILES mapping for reference
+            current_map = {}
+            for key, bp in hp.BUTTON_PROFILES.items():
+                current_map[bp.index] = bp.label
+
+            for i in range(min(count, 20)):
+                offset = 2 + (i * 4)
+                raw = button_data[offset:offset + 4]
+                desc = describe_entry(raw)
+                cur_label = current_map.get(i, "(not in BUTTON_PROFILES)")
+                print(f"  Index {i:2d}  [{raw[0]:02X} {raw[1]:02X} {raw[2]:02X} {raw[3]:02X}]  "
+                      f"{desc:30s}  currently mapped as: {cur_label}")
+            print()
+
+            if prof == profile:
+                print("  ^^^ This is the ACTIVE profile ^^^")
+                print()
+    finally:
+        dev.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/holtek_protocol.py
+++ b/holtek_protocol.py
@@ -1,0 +1,1021 @@
+"""Holtek Venus MMO (04D9:FC55) USB HID Protocol Implementation.
+
+Reverse-engineered from Windows driver hid.exe v1.3.4 binary analysis and live
+device probing. Uses Interface 2 (vendor HID, Usage Page 0xFFA0) with feature
+reports. Report ID 0x02 (16 bytes) and 0x03 (64 bytes). No checksums.
+
+Communication: send_feature_report -> get_feature_report (NOT interrupt reads).
+
+Key discovery from binary analysis: F3 writes persist to flash but DO NOT take
+effect until the firmware receives a category-specific F1 commit command. The F1
+commit byte 3 is a bitmask: 0x01=enter write mode, 0x02=commit buttons,
+0x04=commit DPI, 0x08=commit LED, 0x10=exit/finalize.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import hid
+import time
+
+
+# -- Device Constants --
+VENDOR_ID = 0x04D9
+PRODUCT_ID = 0xFC55
+INTERFACE = 2  # Vendor HID config interface
+
+# Report IDs
+RID_SHORT = 0x02  # 16 bytes total
+RID_LONG = 0x03   # 64 bytes total
+
+# Commands (byte 1 after report ID)
+CMD_WRITE_CTRL = 0xF1
+CMD_READ = 0xF2
+CMD_WRITE_DATA = 0xF3
+CMD_POLLING = 0xF5
+
+# -- F1 Write Control Sub-commands --
+# Byte 2 = 0x02 means "flash write control", byte 3 is category bitmask.
+# These are the CRITICAL commit commands that make F3 writes take effect.
+CTRL_ENTER_WRITE   = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x02, 0x01])  # Enter write mode
+CTRL_COMMIT_BTN    = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x02, 0x02])  # Commit button writes
+CTRL_COMMIT_DPI    = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x02, 0x04])  # Commit DPI writes
+CTRL_COMMIT_LED    = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x02, 0x08])  # Commit LED writes
+CTRL_EXIT_WRITE    = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x02, 0x10])  # Exit write mode / finalize
+# Legacy aliases (byte 2 = 0x00 variants, used in post-commit cleanup)
+CTRL_POST_COMMIT_1 = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x00, 0x04])
+CTRL_POST_COMMIT_2 = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x00, 0x01])
+CTRL_RESET         = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x00, 0x00])
+CTRL_FLASH_ACK     = bytes([RID_SHORT, CMD_WRITE_CTRL, 0x00, 0x08])
+
+# Backward compat alias
+CTRL_COMMIT = CTRL_COMMIT_BTN
+
+# -- Memory Addresses --
+# DPI summary region (status mirror, NOT used by firmware for active DPI)
+ADDR_DPI_SUMMARY     = 0x0020  # 10 bytes: mirrors DPI values (not authoritative)
+ADDR_DPI_STAGE       = 0x002C  # 2 bytes: [current_stage, 0x00]
+ADDR_LED_SETTINGS    = 0x0032  # 5 bytes: LED mode/color settings
+ADDR_LED_EXTRA       = 0x0038  # 3 bytes: additional LED config
+ADDR_ACTIVE_PROFILE  = 0x003D  # 1 byte: (value & 0x7F) = active profile index
+
+# Profile base addresses
+PROFILE_BASE_ADDRS = [0x0040, 0x0100, 0x01B0, 0x0260, 0x0310]
+
+# Per-profile DPI addresses (verified working by user testing)
+# Header at profile_base: [num_stages, 0x00, current_stage_idx, 0x00]
+# DPI entries at profile_base + 4: 6 bytes each [0x01, raw_dpi, color, 0, 0, 0]
+# raw_dpi * 200 = DPI in CPI. color = LED color index for stage indicator.
+ADDR_DPI_PROFILE = [base + 0x04 for base in PROFILE_BASE_ADDRS]
+# = [0x0044, 0x0104, 0x01B4, 0x0264, 0x0314]
+DPI_ENTRY_SIZE = 6  # bytes per DPI stage entry
+
+# Per-profile LED addresses (verified from device memory dump)
+# Format: [0x80, R, G, B, mode, brightness, speed, extra] = 8 bytes each
+# Factory defaults: profile 0=Red, 1=Blue, 2=Green, 3=Magenta, 4=Yellow
+ADDR_LED_PROFILE = [0x0448, 0x0450, 0x0458, 0x0460, 0x0468]
+
+# LED color table at 0x0400 (used for color cycling modes)
+ADDR_LED_COLOR_TABLE = 0x0400
+
+# Per-profile button map addresses
+# Each profile has: 2-byte LE count + 20×4 byte entries starting at profile_base + 0x40
+ADDR_BUTTONS_PROFILE = [base + 0x40 for base in PROFILE_BASE_ADDRS]
+# = [0x0080, 0x0140, 0x01F0, 0x02A0, 0x0350]
+
+# Legacy aliases (profile 0)
+ADDR_BUTTONS       = ADDR_BUTTONS_PROFILE[0]  # Button map start (2-byte count + 20x4 bytes)
+ADDR_BUTTONS_DATA  = ADDR_BUTTONS + 2          # First button entry (after 2-byte count)
+ADDR_BUTTONS_END   = ADDR_BUTTONS + 2 + 20*4   # End of button map region
+
+# Legacy aliases for backward compat
+ADDR_DPI = ADDR_DPI_SUMMARY
+ADDR_LED = ADDR_LED_SETTINGS
+ADDR_POLLING = ADDR_LED_EXTRA  # Polling is set via F5, not memory write
+
+# Button type constants
+BTN_LMB = 0x81
+BTN_RMB = 0x82
+BTN_MMB = 0x83
+BTN_BACK = 0x84
+BTN_FORWARD = 0x85
+BTN_DPI_UP = 0x8A
+BTN_DPI_DOWN = 0x89  # Holtek uses 0x89 (not 0x8C like Venus Pro)
+BTN_PROFILE = 0x8D
+BTN_KEYBOARD = 0x90
+BTN_FIRE = 0x92      # Fire Key / rapid click (Holtek-specific)
+BTN_DISABLED = 0x00
+
+# Human-readable type names
+BUTTON_TYPE_NAMES = {
+    BTN_LMB: "Left Click",
+    BTN_RMB: "Right Click",
+    BTN_MMB: "Middle Click",
+    BTN_BACK: "Back",
+    BTN_FORWARD: "Forward",
+    BTN_DPI_UP: "DPI Up",
+    BTN_DPI_DOWN: "DPI Down",
+    BTN_PROFILE: "Profile Switch",
+    BTN_KEYBOARD: "Keyboard Key",
+    BTN_FIRE: "Fire Key",
+    BTN_DISABLED: "Disabled",
+}
+
+# Action name to button type constant (for GUI -> protocol)
+ACTION_TO_BTN_TYPE = {
+    "Left Click": BTN_LMB,
+    "Right Click": BTN_RMB,
+    "Middle Click": BTN_MMB,
+    "Back": BTN_BACK,
+    "Forward": BTN_FORWARD,
+    "DPI Up": BTN_DPI_UP,
+    "DPI Down": BTN_DPI_DOWN,
+    "DPI Control": None,  # handled specially
+    "Profile Switch": BTN_PROFILE,
+    "Keyboard Key": BTN_KEYBOARD,
+    "Fire Key": BTN_FIRE,
+    "Disabled": BTN_DISABLED,
+}
+
+
+@dataclass(frozen=True)
+class HoltekButtonProfile:
+    label: str
+    index: int  # 0-based index into the 20-button map
+
+
+# 20-button memory map — derived from factory defaults read off device.
+# Verified 2026-02-14 by comparing factory defaults across profiles 1-4:
+#   Index 3 = Fire Key (factory 0x92), Index 5 = DPI Down (factory 0x89),
+#   Index 19 = Profile Switch (factory 0x8D), Index 18 = unused (factory 0x00).
+# Side buttons 1-12 at indices 6-17 (side N defaults to Numpad N, so side 8 at 6+7=13).
+# Physical buttons: LMB, RMB, MMB, Fire, DPI Up, DPI Down, Side 1-12, Profile Switch = 19 buttons.
+# Device firmware has 20 memory slots; index 18 has no physical button.
+BUTTON_PROFILES = {
+    "Button 1":  HoltekButtonProfile("Left Mouse Button", 0),
+    "Button 2":  HoltekButtonProfile("Right Mouse Button", 1),
+    "Button 3":  HoltekButtonProfile("Middle Mouse Button", 2),
+    "Button 4":  HoltekButtonProfile("Fire Key", 3),
+    "Button 5":  HoltekButtonProfile("DPI Up", 4),
+    "Button 6":  HoltekButtonProfile("DPI Down", 5),
+    "Button 7":  HoltekButtonProfile("Side Button 1", 6),
+    "Button 8":  HoltekButtonProfile("Side Button 2", 7),
+    "Button 9":  HoltekButtonProfile("Side Button 3", 8),
+    "Button 10": HoltekButtonProfile("Side Button 4", 9),
+    "Button 11": HoltekButtonProfile("Side Button 5", 10),
+    "Button 12": HoltekButtonProfile("Side Button 6", 11),
+    "Button 13": HoltekButtonProfile("Side Button 7", 12),
+    "Button 14": HoltekButtonProfile("Side Button 8", 13),
+    "Button 15": HoltekButtonProfile("Side Button 9", 14),
+    "Button 16": HoltekButtonProfile("Side Button 10", 15),
+    "Button 17": HoltekButtonProfile("Side Button 11", 16),
+    "Button 18": HoltekButtonProfile("Side Button 12", 17),
+    "Button 20": HoltekButtonProfile("Profile Switch", 19),
+}
+
+# Default button assignments (factory defaults from profiles 1-4).
+# Side buttons 1-12 default to Numpad 1-9, 0, -, + (HID 0x59-0x62, 0x56, 0x57).
+DEFAULT_BUTTON_MAP = [
+    (BTN_LMB, 0x00, 0x00, 0x00),        #  0: Left Mouse Button
+    (BTN_RMB, 0x00, 0x00, 0x00),        #  1: Right Mouse Button
+    (BTN_MMB, 0x00, 0x00, 0x00),        #  2: Middle Mouse Button
+    (BTN_FIRE, 0x03, 0x01, 0x00),       #  3: Fire Key (factory default)
+    (BTN_DPI_UP, 0x00, 0x00, 0x00),     #  4: DPI Up
+    (BTN_DPI_DOWN, 0x00, 0x00, 0x00),   #  5: DPI Down
+    (BTN_KEYBOARD, 0x00, 0x59, 0x00),   #  6: Side 1  → Numpad 1
+    (BTN_KEYBOARD, 0x00, 0x5A, 0x00),   #  7: Side 2  → Numpad 2
+    (BTN_KEYBOARD, 0x00, 0x5B, 0x00),   #  8: Side 3  → Numpad 3
+    (BTN_KEYBOARD, 0x00, 0x5C, 0x00),   #  9: Side 4  → Numpad 4
+    (BTN_KEYBOARD, 0x00, 0x5D, 0x00),   # 10: Side 5  → Numpad 5
+    (BTN_KEYBOARD, 0x00, 0x5E, 0x00),   # 11: Side 6  → Numpad 6
+    (BTN_KEYBOARD, 0x00, 0x5F, 0x00),   # 12: Side 7  → Numpad 7
+    (BTN_KEYBOARD, 0x00, 0x60, 0x00),   # 13: Side 8  → Numpad 8
+    (BTN_KEYBOARD, 0x00, 0x61, 0x00),   # 14: Side 9  → Numpad 9
+    (BTN_KEYBOARD, 0x00, 0x62, 0x00),   # 15: Side 10 → Numpad 0
+    (BTN_KEYBOARD, 0x00, 0x56, 0x00),   # 16: Side 11 → Numpad -
+    (BTN_KEYBOARD, 0x00, 0x57, 0x00),   # 17: Side 12 → Numpad +
+    (BTN_DISABLED, 0x00, 0x00, 0x00),   # 18: (unused slot - no physical button)
+    (BTN_PROFILE, 0x00, 0x00, 0x00),    # 19: Profile Switch
+]
+
+# HID keyboard scancodes (same as Venus Pro HID_KEY_USAGE for the most part)
+# Reuse venus_protocol's HID_KEY_USAGE via import in the GUI
+# Here we just need the mapping for building packets
+
+
+# Polling rates supported by Holtek
+POLLING_RATES = {
+    125: 0x08,   # Code for 125Hz
+    250: 0x04,   # Code for 250Hz
+    500: 0x02,   # Code for 500Hz
+    1000: 0x01,  # Code for 1000Hz
+}
+
+POLLING_CODE_TO_RATE = {v: k for k, v in POLLING_RATES.items()}
+
+
+# -- DPI Encoding --
+# From the DPI lookup table in hid.exe .rdata at 0x47e4c8:
+# Formula: raw_value * 200 = DPI in CPI
+# raw_value range: 0x01 (200 DPI) to 0x8C (28000 DPI)
+DPI_STEP = 200  # Each raw unit = 200 DPI
+
+
+def dpi_to_raw(dpi: int) -> int:
+    """Convert DPI value to raw byte for the device.
+
+    DPI must be a multiple of 200 in range [200, 28000].
+    """
+    raw = dpi // DPI_STEP
+    if raw < 1:
+        raw = 1
+    elif raw > 0x8C:
+        raw = 0x8C
+    return raw
+
+
+def raw_to_dpi(raw: int) -> int:
+    """Convert raw device byte to DPI value."""
+    return raw * DPI_STEP
+
+
+# Common DPI presets from the Windows driver lookup table
+DPI_PRESETS = {
+    800: 0x04,
+    1200: 0x06,
+    1600: 0x08,
+    2400: 0x0C,
+    3200: 0x10,
+    4000: 0x14,
+    4800: 0x18,
+    6400: 0x20,
+    8000: 0x28,
+    12000: 0x3C,
+    16000: 0x50,
+    16400: 0x52,  # Mouse's advertised max
+}
+
+
+class HoltekDevice:
+    """Device wrapper for Holtek Venus MMO (04D9:FC55).
+
+    Uses HID feature reports on Interface 2.
+    Communication: send_feature_report + get_feature_report (no interrupt reads).
+    """
+
+    def __init__(self, path: str):
+        self._path = path
+        self._dev: Optional[hid.device] = None
+
+    def open(self) -> None:
+        if self._dev is not None:
+            return
+        dev = hid.device()
+        dev.open_path(self._path.encode() if isinstance(self._path, str) else self._path)
+        dev.set_nonblocking(True)
+        self._dev = dev
+
+    def close(self) -> None:
+        if self._dev is None:
+            return
+        self._dev.close()
+        self._dev = None
+
+    def send_feature(self, data: bytes) -> None:
+        """Send a feature report (raw bytes including report ID)."""
+        if self._dev is None:
+            raise RuntimeError("device not open")
+        self._dev.send_feature_report(data)
+
+    def get_feature(self, report_id: int, size: int) -> bytes:
+        """Get a feature report response."""
+        if self._dev is None:
+            raise RuntimeError("device not open")
+        # Prepend report ID for get_feature_report
+        buf = bytes([report_id]) + bytes(size - 1)
+        result = self._dev.get_feature_report(report_id, size)
+        return bytes(result) if result else b""
+
+    def send_reliable(self, report: bytes, timeout_ms: int = 500) -> bool:
+        """Send a feature report with a short delay (fire-and-forget).
+
+        Holtek has no ACK mechanism. We just send and wait briefly.
+        Always returns True unless an exception occurs.
+        """
+        self.send_feature(report)
+        time.sleep(0.008)  # 8ms inter-packet delay
+        return True
+
+    def read_memory(self, addr: int, length: int) -> bytes:
+        """Read device memory at the given address.
+
+        Sends F2 read command, then gets feature report for response.
+        Response format: [rid, 0x08, addr_lo, status, length, 0x00, 0xFA, 0xFA, data...]
+        """
+        if self._dev is None:
+            raise RuntimeError("device not open")
+
+        addr_lo = addr & 0xFF
+        addr_hi = (addr >> 8) & 0xFF
+
+        # Build read request
+        req = bytearray(16)
+        req[0] = RID_SHORT
+        req[1] = CMD_READ
+        req[2] = addr_lo
+        req[3] = addr_hi
+        req[4] = length & 0xFF
+
+        self._dev.send_feature_report(bytes(req))
+        time.sleep(0.005)
+
+        # Get response
+        resp = self._dev.get_feature_report(RID_SHORT, 16)
+        if not resp:
+            raise RuntimeError(f"Read failed at 0x{addr:04X}: no response")
+
+        resp = bytes(resp)
+        # Verify response header
+        if len(resp) < 8 + length:
+            raise RuntimeError(f"Read failed at 0x{addr:04X}: short response ({len(resp)} bytes)")
+
+        # Data starts at offset 8 (after header: rid, 0x08, addr_lo, status, length, 0x00, 0xFA, 0xFA)
+        return resp[8:8 + length]
+
+    def read_memory_long(self, addr: int, length: int) -> bytes:
+        """Read device memory using long (64-byte) feature reports for larger reads."""
+        if self._dev is None:
+            raise RuntimeError("device not open")
+
+        addr_lo = addr & 0xFF
+        addr_hi = (addr >> 8) & 0xFF
+
+        # Build read request using short report
+        req = bytearray(16)
+        req[0] = RID_SHORT
+        req[1] = CMD_READ
+        req[2] = addr_lo
+        req[3] = addr_hi
+        req[4] = length & 0xFF
+
+        self._dev.send_feature_report(bytes(req))
+        time.sleep(0.005)
+
+        # For larger reads, get response on long report ID
+        if length > 8:
+            resp = self._dev.get_feature_report(RID_LONG, 64)
+        else:
+            resp = self._dev.get_feature_report(RID_SHORT, 16)
+
+        if not resp:
+            raise RuntimeError(f"Read failed at 0x{addr:04X}: no response")
+
+        resp = bytes(resp)
+        return resp[8:8 + length]
+
+    def write_memory(self, addr: int, data: bytes) -> None:
+        """Write data to device memory using F3 command.
+
+        Packet format: [RID, F3, addr_lo, addr_hi, length, 0x00, 0x00, 0x00, data...]
+        Data starts at byte 8. Max 8 data bytes for short report, 56 for long.
+        Byte 5 MUST be 0x00 or the device will STALL (EPIPE).
+        """
+        addr_lo = addr & 0xFF
+        addr_hi = (addr >> 8) & 0xFF
+
+        if len(data) <= 8:
+            # Short report (16 bytes): 8 header + 8 data max
+            pkt = bytearray(16)
+            pkt[0] = RID_SHORT
+            pkt[1] = CMD_WRITE_DATA
+            pkt[2] = addr_lo
+            pkt[3] = addr_hi
+            pkt[4] = len(data)
+            # pkt[5:8] = 0x00 (already zero)
+            pkt[8:8 + len(data)] = data
+            self.send_feature(bytes(pkt))
+        else:
+            # Long report (64 bytes): 8 header + 56 data max
+            pkt = bytearray(64)
+            pkt[0] = RID_LONG
+            pkt[1] = CMD_WRITE_DATA
+            pkt[2] = addr_lo
+            pkt[3] = addr_hi
+            pkt[4] = len(data)
+            # pkt[5:8] = 0x00 (already zero)
+            pkt[8:8 + len(data)] = data
+            self.send_feature(bytes(pkt))
+        time.sleep(0.008)
+
+    def enter_write_mode(self) -> None:
+        """Enter flash write mode. Must be called before any F3 writes."""
+        self.send_feature(CTRL_ENTER_WRITE.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    def commit_buttons(self) -> None:
+        """Commit button binding writes to flash (F1 category 0x02)."""
+        self.send_feature(CTRL_COMMIT_BTN.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    def commit_dpi(self) -> None:
+        """Commit DPI writes to flash (F1 category 0x04).
+
+        This is the CRITICAL missing step. F3 writes go to flash storage
+        but the firmware does NOT load them until this F1 commit is sent.
+        """
+        self.send_feature(CTRL_COMMIT_DPI.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    def commit_led(self) -> None:
+        """Commit LED writes to flash (F1 category 0x08).
+
+        Like DPI, LED F3 writes persist to flash but don't affect behavior
+        until this category-specific F1 commit command is sent.
+        """
+        self.send_feature(CTRL_COMMIT_LED.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    def exit_write_mode(self) -> None:
+        """Exit write mode / finalize (F1 category 0x10)."""
+        self.send_feature(CTRL_EXIT_WRITE.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    def commit_writes(self, categories: int = 0x0E, reset: bool = True) -> None:
+        """Commit flash writes with category-specific F1 commands.
+
+        Args:
+            categories: Bitmask of categories to commit.
+                0x02 = buttons, 0x04 = DPI, 0x08 = LED.
+                Default 0x0E = all three (buttons + DPI + LED).
+            reset: If True, send device reset after commit so firmware
+                reloads settings from flash. The device will USB-disconnect
+                and reconnect — the handle becomes invalid after this.
+
+        The Windows driver sends individual category commits after each
+        group of related F3 writes, then triggers a device reset so the
+        firmware reloads the new settings from flash.
+        """
+        if categories & 0x02:
+            self.commit_buttons()
+        if categories & 0x04:
+            self.commit_dpi()
+        if categories & 0x08:
+            self.commit_led()
+        self.exit_write_mode()
+        if reset:
+            self.reset_device()
+
+    def reset_device(self) -> None:
+        """Trigger a device reset so firmware reloads settings from flash.
+
+        Sends [F1, 0x00, 0x00] which causes the device to USB-disconnect
+        and reconnect. After this call, the device handle is INVALID —
+        caller must close() and reopen on the new hidraw path.
+        """
+        self.send_feature(CTRL_RESET.ljust(16, b'\x00'))
+        # Device disconnects immediately — no delay needed
+
+    def set_polling_rate(self, rate: int) -> None:
+        """Set polling rate directly using F5 command.
+
+        This takes effect immediately (no F1 commit needed).
+        """
+        code = POLLING_RATES.get(rate)
+        if code is None:
+            raise ValueError(f"Unsupported polling rate: {rate}Hz")
+        pkt = bytearray(16)
+        pkt[0] = RID_SHORT
+        pkt[1] = CMD_POLLING
+        pkt[2] = code
+        self.send_feature(bytes(pkt))
+        time.sleep(0.10)  # Windows driver uses 100ms delay after polling change
+
+    # -- DPI Methods (verified by user testing 2026-02-14) --
+
+    def read_active_profile(self) -> int:
+        """Read the active profile index (0-4)."""
+        data = self.read_memory(ADDR_ACTIVE_PROFILE, 1)
+        return data[0] & 0x7F
+
+    def read_dpi_stages(self, profile: int = 0) -> list[int]:
+        """Read DPI stage values from the per-profile region.
+
+        Header at profile_base: [num_stages, 0x00, current_idx, 0x00]
+        Entries at profile_base+4: 6 bytes each [0x01, raw_dpi, color, 0, 0, 0]
+
+        Returns:
+            List of DPI values in CPI (e.g., [800, 1600, 3200, ...]).
+        """
+        if profile < 0 or profile > 4:
+            raise ValueError(f"Profile must be 0-4, got {profile}")
+
+        base = PROFILE_BASE_ADDRS[profile]
+
+        # Read header to get stage count
+        header = self.read_memory(base, 4)
+        num_stages = header[0]
+        if num_stages == 0 or num_stages > 10:
+            num_stages = 5  # fallback
+
+        # Read DPI entries (6 bytes each, starting at base+4)
+        entry_addr = base + 4
+        total_bytes = num_stages * DPI_ENTRY_SIZE
+        # Read in chunks
+        raw_data = bytearray()
+        for offset in range(0, total_bytes, 8):
+            addr = entry_addr + offset
+            chunk = self.read_memory(addr, min(8, total_bytes - offset))
+            raw_data.extend(chunk)
+
+        dpi_list = []
+        for i in range(num_stages):
+            entry_start = i * DPI_ENTRY_SIZE
+            if entry_start + 1 >= len(raw_data):
+                break
+            raw_dpi = raw_data[entry_start + 1]  # byte 1 = raw DPI value
+            if raw_dpi == 0:
+                break
+            dpi_list.append(raw_to_dpi(raw_dpi))
+        return dpi_list
+
+    def read_current_dpi_stage(self, profile: int = 0) -> int:
+        """Read the current DPI stage index from per-profile header."""
+        base = PROFILE_BASE_ADDRS[profile] if 0 <= profile <= 4 else PROFILE_BASE_ADDRS[0]
+        header = self.read_memory(base, 4)
+        return header[2]  # byte 2 = current stage index
+
+    def write_dpi_stages(self, dpi_values: list[int], profile: int = 0) -> None:
+        """Write DPI stage values to the per-profile region and commit.
+
+        Per-profile DPI at profile_base + 4, 6 bytes per entry:
+        [0x01, raw_dpi, 0x00, 0x00, 0x00, 0x00]
+
+        Args:
+            dpi_values: List of DPI values in CPI (multiples of 200).
+            profile: Profile index (0-4).
+        """
+        if profile < 0 or profile > 4:
+            raise ValueError(f"Profile must be 0-4, got {profile}")
+        if not dpi_values:
+            raise ValueError("At least one DPI value required")
+        if len(dpi_values) > 10:
+            raise ValueError("Maximum 10 DPI stages")
+
+        base = PROFILE_BASE_ADDRS[profile]
+
+        # Write header: [num_stages, 0x00, current_stage=0, 0x00]
+        self.write_memory(base, bytes([len(dpi_values), 0x00, 0x00, 0x00]))
+
+        # Build 6-byte entries
+        entry_data = bytearray()
+        for dpi in dpi_values:
+            entry_data.extend([0x01, dpi_to_raw(dpi), 0x00, 0x00, 0x00, 0x00])
+
+        # Write entries at base+4 in 8-byte chunks
+        entry_addr = base + 4
+        for offset in range(0, len(entry_data), 8):
+            chunk = bytes(entry_data[offset:offset + 8])
+            self.write_memory(entry_addr + offset, chunk)
+
+        # Commit DPI and reset
+        self.commit_dpi()
+        self.exit_write_mode()
+        self.reset_device()
+
+    def set_current_dpi_stage(self, stage: int) -> None:
+        """Set the active DPI stage index.
+
+        Writes to address 0x002C and commits with F1 enter-write (0x01).
+        """
+        self.write_memory(ADDR_DPI_STAGE, bytes([stage, 0x00]))
+        self.send_feature(CTRL_ENTER_WRITE.ljust(16, b'\x00'))
+        time.sleep(0.01)
+
+    # -- LED Methods (corrected from binary analysis) --
+
+    def read_led_settings(self, profile: int = 0) -> dict:
+        """Read LED settings from the per-profile address.
+
+        Per-profile LED at 0x0448 + profile * 8, format:
+        [0x80, R, G, B, mode, brightness, speed, extra]
+        """
+        if profile < 0 or profile > 4:
+            raise ValueError(f"Profile must be 0-4, got {profile}")
+
+        addr = ADDR_LED_PROFILE[profile]
+        data = self.read_memory(addr, 8)
+
+        return {
+            'r': data[1],
+            'g': data[2],
+            'b': data[3],
+            'mode': data[4],
+            'brightness': data[5],
+            'speed': data[6],
+            'raw': bytes(data),
+        }
+
+    def write_led_settings(self, r: int, g: int, b: int,
+                           mode: int = 3, brightness: int = 5,
+                           speed: int = 1, profile: int = 0) -> None:
+        """Write LED configuration and commit to flash.
+
+        Per-profile LED at 0x0448 + profile * 8 (8 bytes).
+        Format: [0x80, R, G, B, mode, brightness, speed, extra]
+
+        Factory defaults per profile:
+            0: Red (FF,00,00), 1: Blue (00,00,FF), 2: Green (00,FF,00),
+            3: Magenta (FF,00,FF), 4: Yellow (FF,FF,00)
+            All with mode=3, brightness=5, speed=1, extra=3.
+
+        Args:
+            r, g, b: Color values (0-255).
+            mode: LED mode (factory default 3).
+            brightness: Brightness level (factory default 5).
+            speed: Animation speed (factory default 1).
+            profile: Profile index (0-4).
+        """
+        if profile < 0 or profile > 4:
+            raise ValueError(f"Profile must be 0-4, got {profile}")
+
+        # Write per-profile LED at 0x0448 + profile * 8
+        addr = ADDR_LED_PROFILE[profile]
+        led_data = bytes([0x80, r & 0xFF, g & 0xFF, b & 0xFF,
+                          mode & 0xFF, brightness & 0xFF,
+                          speed & 0xFF, 0x03])
+        self.write_memory(addr, led_data)
+
+        # Commit LED changes and reset so firmware reloads them
+        self.commit_led()
+        self.exit_write_mode()
+        self.reset_device()
+
+
+def read_all_config(device: HoltekDevice, profile: int | None = None) -> dict:
+    """Read full device configuration for a specific profile.
+
+    Args:
+        device: Open HoltekDevice instance.
+        profile: Profile index (0-4). If None, reads the active profile from device.
+
+    Returns dict with keys: 'dpi_stages', 'dpi_stage_current', 'active_profile',
+    'led', 'buttons', 'raw_button_data', 'dpi_raw', 'led_raw'
+    """
+    config = {}
+
+    # Read active profile from device
+    config['active_profile'] = device.read_active_profile()
+
+    # Use specified profile or fall back to active
+    if profile is not None and 0 <= profile <= 4:
+        read_profile = profile
+    else:
+        read_profile = config['active_profile']
+
+    # Read DPI stages for the selected profile
+    try:
+        config['dpi_stages'] = device.read_dpi_stages(read_profile)
+    except Exception:
+        config['dpi_stages'] = []
+
+    # Read current DPI stage index
+    try:
+        config['dpi_stage_current'] = device.read_current_dpi_stage(read_profile)
+    except Exception:
+        config['dpi_stage_current'] = 0
+
+    # Read LED settings from per-profile address
+    try:
+        config['led'] = device.read_led_settings(read_profile)
+    except Exception:
+        config['led'] = {}
+
+    # Read DPI summary region (0x20-0x2F) for backward compat
+    settings_data = bytearray()
+    for addr in range(0x20, 0x40, 8):
+        chunk = device.read_memory(addr, 8)
+        settings_data.extend(chunk)
+    config['dpi_raw'] = bytes(settings_data[0:16])
+    config['led_raw'] = bytes(settings_data[16:32])
+
+    # Read button map region for the selected profile
+    btn_base = ADDR_BUTTONS_PROFILE[read_profile]
+    btn_end = btn_base + 2 + 20 * 4  # 2-byte count + 20×4 data bytes
+    button_data = bytearray()
+    for addr in range(btn_base, btn_end, 8):
+        chunk_len = min(8, btn_end - addr)
+        chunk = device.read_memory(addr, chunk_len)
+        button_data.extend(chunk)
+
+    # Parse buttons
+    config['raw_button_data'] = bytes(button_data)
+    config['buttons'] = parse_button_map(button_data)
+
+    return config
+
+
+def parse_button_map(data: bytes) -> list[dict]:
+    """Parse the button map from raw data starting at address 0x80.
+
+    Format: 2-byte LE count, then count x 4-byte entries.
+    Each entry: [type_lo, type_hi, code_lo, code_hi]
+    """
+    if len(data) < 2:
+        return []
+
+    count = data[0] | (data[1] << 8)
+    buttons = []
+
+    for i in range(min(count, 20)):
+        offset = 2 + (i * 4)
+        if offset + 4 > len(data):
+            break
+
+        type_lo = data[offset]
+        type_hi = data[offset + 1]
+        code_lo = data[offset + 2]
+        code_hi = data[offset + 3]
+
+        btn_type = type_lo  # Primary type byte
+        hid_code = code_lo  # HID scancode for keyboard keys
+
+        action = BUTTON_TYPE_NAMES.get(btn_type, f"Unknown (0x{btn_type:02X})")
+
+        buttons.append({
+            'index': i,
+            'type': btn_type,
+            'type_hi': type_hi,
+            'code': hid_code,
+            'code_hi': code_hi,
+            'action': action,
+            'raw': bytes(data[offset:offset + 4]),
+        })
+
+    return buttons
+
+
+def build_button_entry(action: str, params: dict) -> bytes:
+    """Build a 4-byte button map entry for a given action.
+
+    Args:
+        action: Action name (e.g., "Left Click", "Keyboard Key")
+        params: Parameters dict (e.g., {"key": 0x04} for keyboard)
+
+    Returns:
+        4-byte entry: [type_lo, type_hi, code_lo, code_hi]
+    """
+    if action == "Keyboard Key":
+        hid_key = params.get("key", 0)
+        return bytes([BTN_KEYBOARD, 0x00, hid_key, 0x00])
+
+    elif action == "Left Click":
+        return bytes([BTN_LMB, 0x00, 0x00, 0x00])
+    elif action == "Right Click":
+        return bytes([BTN_RMB, 0x00, 0x00, 0x00])
+    elif action == "Middle Click":
+        return bytes([BTN_MMB, 0x00, 0x00, 0x00])
+    elif action == "Back":
+        return bytes([BTN_BACK, 0x00, 0x00, 0x00])
+    elif action == "Forward":
+        return bytes([BTN_FORWARD, 0x00, 0x00, 0x00])
+
+    elif action == "DPI Control":
+        func = params.get("func", 1)
+        if func == 2:  # DPI Up
+            return bytes([BTN_DPI_UP, 0x00, 0x00, 0x00])
+        elif func == 3:  # DPI Down
+            return bytes([BTN_DPI_DOWN, 0x00, 0x00, 0x00])
+        else:  # DPI Loop / default
+            return bytes([BTN_DPI_UP, 0x00, 0x00, 0x00])
+
+    elif action == "Profile Switch":
+        return bytes([BTN_PROFILE, 0x00, 0x00, 0x00])
+
+    elif action == "Fire Key":
+        # Holtek fire key: type 0x92, type_hi=repeat, code_lo=0x01
+        repeat = params.get("repeat", 3)
+        return bytes([BTN_FIRE, repeat & 0xFF, 0x01, 0x00])
+
+    elif action == "Disabled":
+        return bytes([BTN_DISABLED, 0x00, 0x00, 0x00])
+
+    # Default: disabled
+    return bytes([BTN_DISABLED, 0x00, 0x00, 0x00])
+
+
+def build_write_packets(button_index: int, action: str, params: dict,
+                        profile: int = 0) -> list[bytes]:
+    """Build feature report packets to write a single button entry.
+
+    The button map starts at ADDR_BUTTONS_PROFILE[profile] + 2 (after 2-byte count).
+    Each button is 4 bytes: addr = base + 2 + button_index * 4.
+
+    Returns list of raw feature report bytes (F3 commands).
+    """
+    entry = build_button_entry(action, params)
+    base = ADDR_BUTTONS_PROFILE[profile] if 0 <= profile <= 4 else ADDR_BUTTONS_PROFILE[0]
+    addr = base + 2 + (button_index * 4)
+
+    # Build F3 write packet (data at byte 8)
+    pkt = bytearray(16)
+    pkt[0] = RID_SHORT
+    pkt[1] = CMD_WRITE_DATA
+    pkt[2] = addr & 0xFF
+    pkt[3] = (addr >> 8) & 0xFF
+    pkt[4] = len(entry)  # length
+    # pkt[5:8] = 0x00 (reserved, must be zero)
+    pkt[8:8 + len(entry)] = entry
+
+    return [bytes(pkt)]
+
+
+def build_button_map_packets(buttons: list[tuple[str, dict]],
+                             profile: int = 0) -> list[bytes]:
+    """Build packets to write the full button map.
+
+    Args:
+        buttons: List of (action, params) tuples for all 20 buttons.
+        profile: Profile index (0-4).
+
+    Returns list of F3 write packets.
+    """
+    packets = []
+    base = ADDR_BUTTONS_PROFILE[profile] if 0 <= profile <= 4 else ADDR_BUTTONS_PROFILE[0]
+
+    # Write count first (2 bytes LE at base address)
+    count = len(buttons)
+    count_pkt = bytearray(16)
+    count_pkt[0] = RID_SHORT
+    count_pkt[1] = CMD_WRITE_DATA
+    count_pkt[2] = base & 0xFF
+    count_pkt[3] = (base >> 8) & 0xFF
+    count_pkt[4] = 2     # length = 2 bytes
+    # count_pkt[5:8] = 0x00 (reserved)
+    count_pkt[8] = count & 0xFF
+    count_pkt[9] = (count >> 8) & 0xFF
+    packets.append(bytes(count_pkt))
+
+    # Write each button entry
+    for i, (action, params) in enumerate(buttons):
+        packets.extend(build_write_packets(i, action, params, profile=profile))
+
+    return packets
+
+
+def build_dpi_packets(dpi_values: list[int], profile: int = 0) -> list[bytes]:
+    """Build packets to write DPI configuration to the per-profile region.
+
+    Per-profile DPI at profile_base + 4, 6 bytes per entry:
+    [0x01, raw_dpi, 0x00, 0x00, 0x00, 0x00]
+    Header at profile_base: [num_stages, 0x00, 0x00, 0x00]
+
+    IMPORTANT: Caller must send F1 commit with category 0x04 (CTRL_COMMIT_DPI)
+    and then reset_device() for the changes to take effect.
+    """
+    packets = []
+
+    if not dpi_values or profile < 0 or profile > 4:
+        return packets
+
+    base = PROFILE_BASE_ADDRS[profile]
+
+    # Write header: [num_stages, 0x00, current_stage=0, 0x00]
+    hdr_pkt = bytearray(16)
+    hdr_pkt[0] = RID_SHORT
+    hdr_pkt[1] = CMD_WRITE_DATA
+    hdr_pkt[2] = base & 0xFF
+    hdr_pkt[3] = (base >> 8) & 0xFF
+    hdr_pkt[4] = 4  # 4 header bytes
+    hdr_pkt[8] = len(dpi_values)
+    hdr_pkt[9] = 0x00
+    hdr_pkt[10] = 0x00  # current stage = 0
+    hdr_pkt[11] = 0x00
+    packets.append(bytes(hdr_pkt))
+
+    # Build 6-byte entries
+    entry_data = bytearray()
+    for dpi in dpi_values:
+        entry_data.extend([0x01, dpi_to_raw(dpi), 0x00, 0x00, 0x00, 0x00])
+
+    # Write entries at base+4 in 8-byte chunks
+    entry_addr = base + 4
+    for offset in range(0, len(entry_data), 8):
+        chunk = entry_data[offset:offset + 8]
+        pkt = bytearray(16)
+        pkt[0] = RID_SHORT
+        pkt[1] = CMD_WRITE_DATA
+        pkt[2] = (entry_addr + offset) & 0xFF
+        pkt[3] = ((entry_addr + offset) >> 8) & 0xFF
+        pkt[4] = len(chunk)
+        pkt[8:8 + len(chunk)] = chunk
+        packets.append(bytes(pkt))
+
+    return packets
+
+
+def build_led_packets(r: int, g: int, b: int, mode: int = 3,
+                      brightness: int = 5, speed: int = 1,
+                      profile: int = 0) -> list[bytes]:
+    """Build packets to write LED configuration.
+
+    Per-profile LED at 0x0448 + profile * 8, format:
+    [0x80, R, G, B, mode, brightness, speed, extra]
+
+    IMPORTANT: Caller must send F1 commit with category 0x08 (CTRL_COMMIT_LED)
+    after sending these packets for the changes to take effect.
+    """
+    packets = []
+
+    if 0 <= profile <= 4:
+        addr = ADDR_LED_PROFILE[profile]
+        pkt = bytearray(16)
+        pkt[0] = RID_SHORT
+        pkt[1] = CMD_WRITE_DATA
+        pkt[2] = addr & 0xFF
+        pkt[3] = (addr >> 8) & 0xFF
+        pkt[4] = 8  # 8 bytes
+        pkt[8] = 0x80  # LED enabled flag
+        pkt[9] = r & 0xFF
+        pkt[10] = g & 0xFF
+        pkt[11] = b & 0xFF
+        pkt[12] = mode & 0xFF
+        pkt[13] = brightness & 0xFF
+        pkt[14] = speed & 0xFF
+        pkt[15] = 0x03  # extra byte (factory default)
+        packets.append(bytes(pkt))
+
+    return packets
+
+
+def build_polling_packet(rate: int) -> bytes:
+    """Build F5 polling rate packet."""
+    code = POLLING_RATES.get(rate)
+    if code is None:
+        raise ValueError(f"Unsupported polling rate: {rate}Hz")
+    pkt = bytearray(16)
+    pkt[0] = RID_SHORT
+    pkt[1] = CMD_POLLING
+    pkt[2] = code
+    return bytes(pkt)
+
+
+def button_action_to_gui(btn_type: int, code: int) -> tuple[str, dict]:
+    """Convert Holtek button type/code to GUI action/params format.
+
+    Returns: (action_name, params_dict) matching the GUI's format.
+    """
+    if btn_type == BTN_LMB:
+        return "Left Click", {}
+    elif btn_type == BTN_RMB:
+        return "Right Click", {}
+    elif btn_type == BTN_MMB:
+        return "Middle Click", {}
+    elif btn_type == BTN_BACK:
+        return "Back", {}
+    elif btn_type == BTN_FORWARD:
+        return "Forward", {}
+    elif btn_type == BTN_DPI_UP:
+        return "DPI Control", {"func": 2}
+    elif btn_type == BTN_DPI_DOWN:
+        return "DPI Control", {"func": 3}
+    elif btn_type == BTN_PROFILE:
+        return "Profile Switch", {}
+    elif btn_type == BTN_FIRE:
+        return "Fire Key", {"repeat": code}
+    elif btn_type == BTN_KEYBOARD:
+        return "Keyboard Key", {"key": code, "mod": 0}
+    elif btn_type == BTN_DISABLED:
+        return "Disabled", {}
+    else:
+        return f"Unknown (0x{btn_type:02X})", {}
+
+
+def find_device_path() -> Optional[str]:
+    """Find the hidraw path for the Holtek Venus MMO device (Interface 2).
+
+    Returns the path string, or None if not found.
+    """
+    for info in hid.enumerate(VENDOR_ID, PRODUCT_ID):
+        if info["interface_number"] == INTERFACE:
+            path = info["path"]
+            return path.decode() if isinstance(path, bytes) else path
+    return None
+
+
+def wait_for_device(timeout: float = 5.0) -> Optional[str]:
+    """Wait for the device to appear after a reset/replug.
+
+    Args:
+        timeout: Maximum seconds to wait.
+
+    Returns:
+        The new device path, or None if timeout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        path = find_device_path()
+        if path:
+            return path
+        time.sleep(0.3)
+    return None

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,8 @@ echo "Installing Venus Pro Linux utility..."
 # Install main files
 sudo install -Dm755 venus_gui.py /usr/share/venusprolinux/venus_gui.py
 sudo install -Dm644 venus_protocol.py /usr/share/venusprolinux/venus_protocol.py
+sudo install -Dm644 holtek_protocol.py /usr/share/venusprolinux/holtek_protocol.py
+sudo install -Dm644 device_driver.py /usr/share/venusprolinux/device_driver.py
 sudo install -Dm644 staging_manager.py /usr/share/venusprolinux/staging_manager.py
 sudo install -Dm644 transaction_controller.py /usr/share/venusprolinux/transaction_controller.py
 sudo install -Dm644 mouseimg.png /usr/share/venusprolinux/mouseimg.png
@@ -29,8 +31,17 @@ sudo chmod 755 /usr/bin/venusprolinux
 # Update icon cache
 sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/ 2>/dev/null || true
 
-echo "Note: You may need to setup udev rules for non-root access:"
-echo 'echo "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"25a7\", ATTRS{idProduct}==\"fa07\", MODE=\"0666\"" | sudo tee /etc/udev/rules.d/99-venus-pro.rules'
-echo 'echo "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"25a7\", ATTRS{idProduct}==\"fa08\", MODE=\"0666\"" | sudo tee -a /etc/udev/rules.d/99-venus-pro.rules'
-echo 'echo "SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"04d9\", ATTRS{idProduct}==\"fc55\", MODE=\"0666\"" | sudo tee -a /etc/udev/rules.d/99-venus-pro.rules'
-echo 'sudo udevadm control --reload-rules && sudo udevadm trigger'
+# Install udev rules for non-root access (hidraw for hidapi, usb for pyusb magic unlock)
+cat << 'UDEV' | sudo tee /etc/udev/rules.d/99-venus-pro.rules > /dev/null
+# Venus Pro (Wireless Receiver)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
+# Venus Pro (Wired)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
+# Venus MMO (Holtek variant)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
+UDEV
+sudo udevadm control --reload-rules && sudo udevadm trigger
+echo "udev rules installed to /etc/udev/rules.d/99-venus-pro.rules"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,39 +1,52 @@
 # Maintainer: Es00bac <es00bac@example.com>
 pkgname=venus-pro-linux
-pkgver=0.2.1
+pkgver=0.3.0
 pkgrel=1
-pkgdesc="Configuration utility for UtechSmart Venus Pro MMO Mouse (Linux)"
+pkgdesc="Configuration utility for UtechSmart Venus Pro / Venus MMO Mouse (Linux)"
 arch=('any')
 url="https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility"
 license=('MIT')
 depends=('python' 'python-pyqt6' 'python-hidapi' 'hidapi')
-makedepends=('git')
-source=("git+https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git#tag=v${pkgver}")
-md5sums=('SKIP')
+optdepends=('python-evdev: macro playback support'
+            'python-pyusb: magic unlock for macro pages')
+makedepends=()
+source=()
+md5sums=()
+
+# Build from the local git checkout (parent of packaging/arch/)
+_srcdir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 package() {
-    cd "UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility"
-    
-    # 1. Install Libs/Assets to /opt/venusprolinux
+    cd "${_srcdir}"
+
+    # 1. Install Python modules and assets to /opt/venusprolinux
     install -d "${pkgdir}/opt/${pkgname}"
-    install -m644 venus_gui.py venus_protocol.py staging_manager.py transaction_controller.py mouseimg.png icon.png "${pkgdir}/opt/${pkgname}/"
-    
-    # 2. Launcher Script
+    install -m644 venus_gui.py venus_protocol.py holtek_protocol.py \
+                  device_driver.py staging_manager.py transaction_controller.py \
+                  mouseimg.png icon.png \
+                  "${pkgdir}/opt/${pkgname}/"
+
+    # 2. Launcher script
     install -d "${pkgdir}/usr/bin"
-    echo "#!/bin/sh" > "${pkgdir}/usr/bin/venusprolinux"
-    echo "exec python3 /opt/${pkgname}/venus_gui.py \"\$@\"" >> "${pkgdir}/usr/bin/venusprolinux"
+    cat > "${pkgdir}/usr/bin/venusprolinux" <<'LAUNCHER'
+#!/bin/sh
+exec python3 /opt/venus-pro-linux/venus_gui.py "$@"
+LAUNCHER
     chmod 755 "${pkgdir}/usr/bin/venusprolinux"
-    
-    # 3. Desktop File
-    install -d "${pkgdir}/usr/share/applications"
-    install -m644 packaging/linux/venusprolinux.desktop "${pkgdir}/usr/share/applications/${pkgname}.desktop"
-    
+
+    # 3. Desktop entry
+    install -Dm644 packaging/linux/venusprolinux.desktop \
+        "${pkgdir}/usr/share/applications/venusprolinux.desktop"
+
     # 4. Icon
-    install -d "${pkgdir}/usr/share/pixmaps"
-    install -m644 icon.png "${pkgdir}/usr/share/pixmaps/venusprolinux.png"
-    
-    # 5. Udev Rules (Important!)
-    # Assuming user provides them or we include one?
-    # install -d "${pkgdir}/usr/lib/udev/rules.d"
-    # install -m644 99-venus.rules "${pkgdir}/usr/lib/udev/rules.d/"
+    install -Dm644 icon.png \
+        "${pkgdir}/usr/share/pixmaps/venusprolinux.png"
+
+    # 5. Udev rules
+    install -Dm644 packaging/linux/99-venus-pro.rules \
+        "${pkgdir}/usr/lib/udev/rules.d/99-venus-pro.rules"
+
+    # 6. License
+    install -Dm644 LICENSE \
+        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/packaging/linux/99-venus-pro.rules
+++ b/packaging/linux/99-venus-pro.rules
@@ -1,0 +1,14 @@
+# UtechSmart Venus Pro / Venus MMO Gaming Mouse
+# Grants non-root access to hidraw (hidapi) and usb (pyusb) device nodes
+
+# Venus Pro (Wireless Receiver)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
+
+# Venus Pro (Wired)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
+
+# Venus MMO (Holtek variant)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"

--- a/venus_gui.py
+++ b/venus_gui.py
@@ -16,6 +16,8 @@ except ImportError:
     EVDEV_AVAILABLE = False
 
 import venus_protocol as vp
+import holtek_protocol as hp
+import device_driver as dd
 from staging_manager import StagingManager
 from transaction_controller import TransactionController
 
@@ -27,6 +29,122 @@ DEFAULT_MACRO_EVENTS_HEX = (
     "9c810c00005e410c0000bc811100004e41110000cb810a00005e410a00"
 )
 DEFAULT_MACRO_TAIL_HEX = "000369000000"
+
+
+class KeyCaptureEdit(QtWidgets.QLineEdit):
+    """Key capture widget that distinguishes numpad keys from regular keys.
+
+    QKeySequenceEdit cannot tell Numpad 1 from regular 1. This widget checks
+    Qt.KeyboardModifier.KeypadModifier and maps to the correct HID key name
+    (e.g. "Keypad 1" vs "1").
+    """
+
+    keyChanged = QtCore.pyqtSignal()
+
+    # Qt.Key → HID_KEY_USAGE name (regular keys)
+    _QT_TO_HID = {
+        **{getattr(QtCore.Qt.Key, f"Key_{chr(c)}"): chr(c)
+           for c in range(ord("A"), ord("Z") + 1)},
+        QtCore.Qt.Key.Key_1: "1", QtCore.Qt.Key.Key_2: "2",
+        QtCore.Qt.Key.Key_3: "3", QtCore.Qt.Key.Key_4: "4",
+        QtCore.Qt.Key.Key_5: "5", QtCore.Qt.Key.Key_6: "6",
+        QtCore.Qt.Key.Key_7: "7", QtCore.Qt.Key.Key_8: "8",
+        QtCore.Qt.Key.Key_9: "9", QtCore.Qt.Key.Key_0: "0",
+        QtCore.Qt.Key.Key_F1: "F1", QtCore.Qt.Key.Key_F2: "F2",
+        QtCore.Qt.Key.Key_F3: "F3", QtCore.Qt.Key.Key_F4: "F4",
+        QtCore.Qt.Key.Key_F5: "F5", QtCore.Qt.Key.Key_F6: "F6",
+        QtCore.Qt.Key.Key_F7: "F7", QtCore.Qt.Key.Key_F8: "F8",
+        QtCore.Qt.Key.Key_F9: "F9", QtCore.Qt.Key.Key_F10: "F10",
+        QtCore.Qt.Key.Key_F11: "F11", QtCore.Qt.Key.Key_F12: "F12",
+        QtCore.Qt.Key.Key_F13: "F13", QtCore.Qt.Key.Key_F14: "F14",
+        QtCore.Qt.Key.Key_F15: "F15", QtCore.Qt.Key.Key_F16: "F16",
+        QtCore.Qt.Key.Key_F17: "F17", QtCore.Qt.Key.Key_F18: "F18",
+        QtCore.Qt.Key.Key_F19: "F19", QtCore.Qt.Key.Key_F20: "F20",
+        QtCore.Qt.Key.Key_F21: "F21", QtCore.Qt.Key.Key_F22: "F22",
+        QtCore.Qt.Key.Key_F23: "F23", QtCore.Qt.Key.Key_F24: "F24",
+        QtCore.Qt.Key.Key_Return: "Enter", QtCore.Qt.Key.Key_Escape: "Escape",
+        QtCore.Qt.Key.Key_Backspace: "Backspace", QtCore.Qt.Key.Key_Tab: "Tab",
+        QtCore.Qt.Key.Key_Space: "Space",
+        QtCore.Qt.Key.Key_Minus: "-", QtCore.Qt.Key.Key_Equal: "=",
+        QtCore.Qt.Key.Key_BracketLeft: "[", QtCore.Qt.Key.Key_BracketRight: "]",
+        QtCore.Qt.Key.Key_Backslash: "\\", QtCore.Qt.Key.Key_Semicolon: ";",
+        QtCore.Qt.Key.Key_Apostrophe: "'", QtCore.Qt.Key.Key_QuoteLeft: "`",
+        QtCore.Qt.Key.Key_Comma: ",", QtCore.Qt.Key.Key_Period: ".",
+        QtCore.Qt.Key.Key_Slash: "/", QtCore.Qt.Key.Key_CapsLock: "CapsLock",
+        QtCore.Qt.Key.Key_Insert: "Insert", QtCore.Qt.Key.Key_Home: "Home",
+        QtCore.Qt.Key.Key_PageUp: "PageUp", QtCore.Qt.Key.Key_Delete: "Delete",
+        QtCore.Qt.Key.Key_End: "End", QtCore.Qt.Key.Key_PageDown: "PageDown",
+        QtCore.Qt.Key.Key_Right: "Right", QtCore.Qt.Key.Key_Left: "Left",
+        QtCore.Qt.Key.Key_Down: "Down", QtCore.Qt.Key.Key_Up: "Up",
+        QtCore.Qt.Key.Key_Print: "PrintScreen",
+        QtCore.Qt.Key.Key_ScrollLock: "ScrollLock",
+        QtCore.Qt.Key.Key_Pause: "Pause", QtCore.Qt.Key.Key_Menu: "Menu",
+        QtCore.Qt.Key.Key_NumLock: "NumLock",
+        # Modifier keys (standalone binding)
+        QtCore.Qt.Key.Key_Shift: "Left Shift", QtCore.Qt.Key.Key_Control: "Left Ctrl",
+        QtCore.Qt.Key.Key_Alt: "Left Alt", QtCore.Qt.Key.Key_Meta: "Left GUI",
+    }
+
+    # When KeypadModifier is active, override these keys → "Keypad X"
+    _KEYPAD_MAP = {
+        QtCore.Qt.Key.Key_0: "Keypad 0", QtCore.Qt.Key.Key_1: "Keypad 1",
+        QtCore.Qt.Key.Key_2: "Keypad 2", QtCore.Qt.Key.Key_3: "Keypad 3",
+        QtCore.Qt.Key.Key_4: "Keypad 4", QtCore.Qt.Key.Key_5: "Keypad 5",
+        QtCore.Qt.Key.Key_6: "Keypad 6", QtCore.Qt.Key.Key_7: "Keypad 7",
+        QtCore.Qt.Key.Key_8: "Keypad 8", QtCore.Qt.Key.Key_9: "Keypad 9",
+        QtCore.Qt.Key.Key_Slash: "Keypad /", QtCore.Qt.Key.Key_Asterisk: "Keypad *",
+        QtCore.Qt.Key.Key_Minus: "Keypad -", QtCore.Qt.Key.Key_Plus: "Keypad +",
+        QtCore.Qt.Key.Key_Enter: "Keypad Enter",
+        QtCore.Qt.Key.Key_Period: "Keypad .",
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setReadOnly(True)
+        self.setPlaceholderText("Click here, then press a key...")
+        self._hid_name: str = ""
+
+    def hidName(self) -> str:
+        """Return the captured HID key name (e.g. 'Keypad 1', 'A')."""
+        return self._hid_name
+
+    def setHidName(self, name: str) -> None:
+        """Set the key name programmatically (e.g. from device read)."""
+        self._hid_name = name
+        self.setText(name)
+
+    def clear(self) -> None:
+        self._hid_name = ""
+        super().clear()
+
+    def isEmpty(self) -> bool:
+        return not self._hid_name
+
+    # X11 native scan codes for right-side modifiers (left-side handled by _QT_TO_HID)
+    _RIGHT_MOD_SCANCODES = {
+        62: "Right Shift",   # X11 keycode for Right Shift
+        105: "Right Ctrl",   # X11 keycode for Right Ctrl
+        108: "Right Alt",    # X11 keycode for Right Alt
+        134: "Right GUI",    # X11 keycode for Right Super
+    }
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
+        key = event.key()
+        mods = event.modifiers()
+
+        # Check for right-side modifiers via native scan code
+        scan = event.nativeScanCode()
+        if scan in self._RIGHT_MOD_SCANCODES:
+            name = self._RIGHT_MOD_SCANCODES[scan]
+        elif bool(mods & QtCore.Qt.KeyboardModifier.KeypadModifier) and key in self._KEYPAD_MAP:
+            name = self._KEYPAD_MAP[key]
+        else:
+            name = self._QT_TO_HID.get(key, "")
+
+        if name:
+            self._hid_name = name
+            self.setText(name)
+            self.keyChanged.emit()
 
 
 class MacroRunner(QtCore.QThread):
@@ -168,6 +286,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # Store device path instead of keeping device open (prevents blocking mouse input)
         self.device_path: str | None = None
         self.device_infos: list[vp.DeviceInfo] = []
+        self.device_type: str = 'venus_pro'  # 'venus_pro' or 'holtek'
+        self.holtek_profile: int = 0  # 0-4, selected hardware profile for Holtek device
+        self.active_button_profiles: dict = vp.BUTTON_PROFILES
         self.custom_profiles: dict[str, tuple[int, int, int]] = {}
         self.button_assignments: dict[str, dict] = {} # Stored button settings from device
         
@@ -198,6 +319,7 @@ class MainWindow(QtWidgets.QMainWindow):
         
         self.custom_profiles = {}  # key -> (code_hi, code_lo, apply_offset)
         self.current_edit_key = None
+        self._populating_editor = False
         self.button_assignments = {}
         
         # Staging & Transaction
@@ -249,12 +371,24 @@ class MainWindow(QtWidgets.QMainWindow):
         self.import_button = QtWidgets.QPushButton("📂 Import Profile")
         layout.addWidget(self.import_button)
         
+        # Holtek profile selector (only visible when Holtek device connected)
+        self.profile_label = QtWidgets.QLabel("Profile:")
+        self.profile_label.setVisible(False)
+        layout.addWidget(self.profile_label)
+
+        self.profile_combo = QtWidgets.QComboBox()
+        for i in range(5):
+            self.profile_combo.addItem(f"Profile {i + 1}", i)
+        self.profile_combo.setVisible(False)
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+        layout.addWidget(self.profile_combo)
+
         # Reclaim button (for busy devices)
         self.reclaim_button = QtWidgets.QPushButton("⚡ Reclaim Device")
         self.reclaim_button.setToolTip("Attempts to reclaim the device from Wine/VM by re-attaching host drivers.")
         self.reclaim_button.clicked.connect(self._reclaim_device)
         layout.addWidget(self.reclaim_button)
-        
+
         # Hidden combo for logic, but not needed for user interaction mostly
         self.device_combo = QtWidgets.QComboBox()
         self.device_combo.setVisible(False)
@@ -371,15 +505,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self.key_group = QtWidgets.QWidget()
         key_group_layout = QtWidgets.QVBoxLayout(self.key_group)
         key_group_layout.setContentsMargins(0, 0, 0, 0)
-        self.key_select = QtWidgets.QKeySequenceEdit()
-        # Initial empty sequence
-        self.key_select.setKeySequence(QtGui.QKeySequence(""))
+        self.key_select = KeyCaptureEdit()
         self.special_key_combo = QtWidgets.QComboBox()
         self.special_key_combo.addItem("Select special key...", None)
         self.special_key_names = [
             "F13", "F14", "F15", "F16", "F17", "F18", "F19", "F20", "F21", "F22", "F23", "F24",
             "PrintScreen", "ScrollLock", "Pause", "Insert", "Home", "PageUp", "Delete", "End", "PageDown",
             "NumLock", "Menu",
+            "Left Shift", "Left Ctrl", "Left Alt", "Left GUI",
+            "Right Shift", "Right Ctrl", "Right Alt", "Right GUI",
             "Keypad /", "Keypad *", "Keypad -", "Keypad +", "Keypad Enter", "Keypad .",
             "Keypad 0", "Keypad 1", "Keypad 2", "Keypad 3", "Keypad 4",
             "Keypad 5", "Keypad 6", "Keypad 7", "Keypad 8", "Keypad 9",
@@ -388,7 +522,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if key_name in vp.HID_KEY_USAGE:
                 self.special_key_combo.addItem(key_name, key_name)
         self.special_key_combo.currentIndexChanged.connect(self._on_special_key_select)
-        self.key_select.keySequenceChanged.connect(self._clear_special_key_selection)
+        self.key_select.keyChanged.connect(self._clear_special_key_selection)
         self.mod_ctrl = QtWidgets.QCheckBox("Ctrl")
         self.mod_shift = QtWidgets.QCheckBox("Shift")
         self.mod_alt = QtWidgets.QCheckBox("Alt")
@@ -532,7 +666,22 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Connects
         self.action_select.currentTextChanged.connect(self._update_bind_ui)
-        
+
+        # Auto-stage on any editor change
+        self.action_select.currentTextChanged.connect(self._auto_stage_binding)
+        self.key_select.keyChanged.connect(self._auto_stage_binding)
+        self.special_key_combo.currentIndexChanged.connect(self._auto_stage_binding)
+        self.mod_ctrl.stateChanged.connect(self._auto_stage_binding)
+        self.mod_shift.stateChanged.connect(self._auto_stage_binding)
+        self.mod_alt.stateChanged.connect(self._auto_stage_binding)
+        self.mod_win.stateChanged.connect(self._auto_stage_binding)
+        self.macro_index_spin.valueChanged.connect(self._auto_stage_binding)
+        self.macro_repeat_combo.currentIndexChanged.connect(self._auto_stage_binding)
+        self.media_select.currentIndexChanged.connect(self._auto_stage_binding)
+        self.dpi_action_select.currentIndexChanged.connect(self._auto_stage_binding)
+        self.special_delay_spin.valueChanged.connect(self._auto_stage_binding)
+        self.special_repeat_spin.valueChanged.connect(self._auto_stage_binding)
+
         splitter.addWidget(left_widget)
         splitter.addWidget(right_widget)
         splitter.setStretchFactor(0, 1)
@@ -561,20 +710,26 @@ class MainWindow(QtWidgets.QMainWindow):
         self.right_panel_enabled(True)
         
         # Update Advanced / Custom Offsets UI
-        if key in vp.BUTTON_PROFILES:
-            p = vp.BUTTON_PROFILES[key]
+        if key in self.active_button_profiles:
+            p = self.active_button_profiles[key]
             self.code_hi_spin.blockSignals(True)
             self.code_lo_spin.blockSignals(True)
             self.apply_offset_spin.blockSignals(True)
-            
-            self.code_hi_spin.setValue(p.code_hi or 0)
-            self.code_lo_spin.setValue(p.code_lo or 0)
-            self.apply_offset_spin.setValue(p.apply_offset or 0)
-            
+
+            if self.device_type == 'holtek':
+                # Holtek uses index-based addressing, show index in offset
+                self.code_hi_spin.setValue(0)
+                self.code_lo_spin.setValue(0)
+                self.apply_offset_spin.setValue(p.index)
+            else:
+                self.code_hi_spin.setValue(p.code_hi or 0)
+                self.code_lo_spin.setValue(p.code_lo or 0)
+                self.apply_offset_spin.setValue(p.apply_offset or 0)
+
             self.code_hi_spin.blockSignals(False)
             self.code_lo_spin.blockSignals(False)
             self.apply_offset_spin.blockSignals(False)
-            
+
             self.code_hi_spin.setEnabled(False)
             self.code_lo_spin.setEnabled(False)
             self.apply_offset_spin.setEnabled(False)
@@ -611,9 +766,19 @@ class MainWindow(QtWidgets.QMainWindow):
         # Also disable groups?
         
     def _update_ui_from_assignment(self, button_key: str) -> None:
-        """Update editor UI from stored assignment."""
-        if button_key not in self.button_assignments: return
-        assign = self.button_assignments[button_key]
+        """Update editor UI from effective assignment (staged if pending, else base)."""
+        self._populating_editor = True
+        try:
+            self._update_ui_from_assignment_inner(button_key)
+        finally:
+            self._populating_editor = False
+
+    def _update_ui_from_assignment_inner(self, button_key: str) -> None:
+        assign = self.staging_manager.get_effective_state(button_key)
+        if assign is None:
+            if button_key not in self.button_assignments:
+                return
+            assign = self.button_assignments[button_key]
         action = assign["action"]
         params = assign["params"]
         
@@ -640,24 +805,14 @@ class MainWindow(QtWidgets.QMainWindow):
                     if idx >= 0:
                         self.special_key_combo.setCurrentIndex(idx)
                     self.special_key_combo.blockSignals(False)
-                    self.key_select.setKeySequence(QtGui.QKeySequence(""))
+                    self.key_select.clear()
                 else:
                     self.special_key_combo.blockSignals(True)
                     self.special_key_combo.setCurrentIndex(0)
                     self.special_key_combo.blockSignals(False)
-                    # Map HID name back to Qt Key name for display
-                    qt_name_map = {
-                        "Enter": "Return",
-                        "Escape": "Esc",
-                        "Delete": "Del",
-                        "Insert": "Ins",
-                        "PageUp": "PgUp",
-                        "PageDown": "PgDown",
-                    }
-                    qt_name = qt_name_map.get(key_name, key_name)
-                    self.key_select.setKeySequence(QtGui.QKeySequence(qt_name))
+                    self.key_select.setHidName(key_name)
             else:
-                self.key_select.setKeySequence(QtGui.QKeySequence(""))
+                self.key_select.clear()
             
             self.mod_ctrl.setChecked(bool(mod & vp.MODIFIER_CTRL))
             self.mod_shift.setChecked(bool(mod & vp.MODIFIER_SHIFT))
@@ -693,7 +848,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_special_key_select(self) -> None:
         if self.special_key_combo.currentData():
-            self.key_select.setKeySequence(QtGui.QKeySequence(""))
+            self.key_select.clear()
 
     def _clear_special_key_selection(self) -> None:
         if self.special_key_combo.currentIndex() != 0:
@@ -1428,8 +1583,10 @@ class MainWindow(QtWidgets.QMainWindow):
         if button_key is None:
             return
         # If it's a standard profile, we shouldn't be here (locked fields), but check anyway
-        if button_key in vp.BUTTON_PROFILES:
-            profile = vp.BUTTON_PROFILES[button_key]
+        if button_key in self.active_button_profiles:
+            if self.device_type == 'holtek':
+                return  # Holtek profiles are always standard
+            profile = self.active_button_profiles[button_key]
             if profile.code_hi is not None:
                 return
 
@@ -1440,6 +1597,13 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
     def _resolve_profile(self, button_key: str, use_fallback: bool) -> tuple[int, int, int]:
+        # Holtek uses a different profile structure (index-based)
+        if self.device_type == 'holtek':
+            profile = self.active_button_profiles.get(button_key)
+            if profile is not None:
+                return 0, 0, profile.index
+            raise ValueError(f"Unknown Holtek button: {button_key}")
+
         profile = vp.BUTTON_PROFILES[button_key]
         if profile.code_hi is not None and profile.code_lo is not None and profile.apply_offset is not None:
             return profile.code_hi, profile.code_lo, profile.apply_offset
@@ -1520,11 +1684,30 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.device_infos:
             info = self.device_infos[0]
             self.device_path = info.path
-            self.status_label.setText(f"Ready: {info.product}")
-            self._log(f"Connect: Found device: {info.product} at {info.path}")
-            
+
+            # Detect device type and swap profiles
+            new_type = dd.detect_device_type(info)
+            if new_type != self.device_type:
+                self._log(f"Connect: Device type changed: {self.device_type} -> {new_type}")
+            self.device_type = new_type
+            self.active_button_profiles = dd.get_button_profiles(self.device_type)
+            self._rebuild_button_table()
+
+            device_name = vp.DEVICE_NAMES.get((info.vendor_id, info.product_id), info.product)
+            self.status_label.setText(f"Ready: {device_name}")
+            self.setWindowTitle(f"Venus Config v0.2.1 — {device_name}")
+            self._log(f"Connect: Found {device_name} ({self.device_type}) at {info.path}")
+
+            # Show/hide profile selector for Holtek
+            is_holtek = self.device_type == 'holtek'
+            self.profile_label.setVisible(is_holtek)
+            self.profile_combo.setVisible(is_holtek)
+
+            # Guard macro tab for Holtek
+            self._update_macro_tab_availability()
+
             QtWidgets.QApplication.processEvents()
-            
+
             # Auto-read settings on startup
             self._log("Connect: Triggering auto-read settings...")
             self._read_settings()
@@ -1535,6 +1718,48 @@ class MainWindow(QtWidgets.QMainWindow):
     def _auto_connect(self) -> None:
         """Legacy function - handled by _refresh_and_connect now."""
         pass
+
+    def _rebuild_button_table(self) -> None:
+        """Clear and repopulate button table from active_button_profiles."""
+        profiles = self.active_button_profiles
+        self.sorted_btn_keys = sorted(profiles.keys(), key=lambda k: int(k.split()[1]))
+        self._log(f"Rebuild table: {len(self.sorted_btn_keys)} buttons, keys={self.sorted_btn_keys[:3]}...")
+        self.btn_table.clearContents()
+        self.btn_table.setRowCount(len(self.sorted_btn_keys))
+
+        for i, key in enumerate(self.sorted_btn_keys):
+            profile = profiles[key]
+            label = profile.label
+            item_name = QtWidgets.QTableWidgetItem(label)
+            item_name.setData(QtCore.Qt.ItemDataRole.UserRole, key)
+            item_name.setFlags(item_name.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+            self.btn_table.setItem(i, 0, item_name)
+
+            item_assign = QtWidgets.QTableWidgetItem("Unknown (Read to update)")
+            item_assign.setFlags(item_assign.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+            self.btn_table.setItem(i, 1, item_assign)
+
+        # Also update the macro tab's button selector if it exists
+        if hasattr(self, 'macro_button_select'):
+            self.macro_button_select.clear()
+            for key in self.sorted_btn_keys:
+                profile = profiles[key]
+                self.macro_button_select.addItem(profile.label, key)
+
+    def _update_macro_tab_availability(self) -> None:
+        """Enable/disable macro tab based on device type."""
+        # Macros are not yet supported for Holtek devices
+        # Find the Macros tab index and enable/disable it
+        tabs = self.centralWidget().findChild(QtWidgets.QTabWidget)
+        if tabs:
+            for i in range(tabs.count()):
+                if tabs.tabText(i) == "Macros":
+                    tabs.setTabEnabled(i, self.device_type != 'holtek')
+                    if self.device_type == 'holtek':
+                        tabs.setTabToolTip(i, "Macros not yet supported for Venus MMO (Holtek)")
+                    else:
+                        tabs.setTabToolTip(i, "")
+                    break
 
     def _require_device(self, auto_mode: bool = False) -> bool:
         """Check if a device path is available for transient connections."""
@@ -1553,12 +1778,12 @@ class MainWindow(QtWidgets.QMainWindow):
         """Send reports using a transient device connection."""
         if not self._require_device():
             return
-        
+
         device = None
         try:
             import time
-            # Open device transiently
-            device = vp.VenusDevice(self.device_path)
+            # Open device transiently using factory
+            device = dd.create_device(self.device_type, self.device_path)
             device.open()
             
             for report in reports:
@@ -1686,13 +1911,19 @@ class MainWindow(QtWidgets.QMainWindow):
             progress.close()
 
 
-    def _apply_button_binding(self) -> None:
+    def _auto_stage_binding(self) -> None:
+        """Auto-stage the current binding silently (no validation warnings)."""
+        if self._populating_editor:
+            return
+        self._apply_button_binding(silent=True)
+
+    def _apply_button_binding(self, silent: bool = False) -> None:
         if not self.current_edit_key:
             return
 
         action = self.action_select.currentText()
         params = {}
-        
+
         # VALIDATION & PARAMS
         if action == "Macro":
             mode = self.macro_repeat_combo.currentData()
@@ -1706,15 +1937,15 @@ class MainWindow(QtWidgets.QMainWindow):
             if special_key:
                 key_name = special_key
             else:
-                seq = self.key_select.keySequence()
-                if seq.isEmpty():
-                    QtWidgets.QMessageBox.warning(self, "Invalid", "Please press a key combination or choose a special key.")
+                if self.key_select.isEmpty():
+                    if not silent:
+                        QtWidgets.QMessageBox.warning(self, "Invalid", "Please press a key combination or choose a special key.")
                     return
-                # Use our custom capture logic (first key)
-                key_name = seq.toString().split('+')[-1]
+                key_name = self.key_select.hidName()
 
             if not key_name:
-                QtWidgets.QMessageBox.warning(self, "Invalid", "Please press a key combination or choose a special key.")
+                if not silent:
+                    QtWidgets.QMessageBox.warning(self, "Invalid", "Please press a key combination or choose a special key.")
                 return
             
             hid_key = vp.HID_KEY_USAGE.get(key_name, 0) or vp.HID_KEY_USAGE.get(key_name.upper(), 0)
@@ -1749,9 +1980,11 @@ class MainWindow(QtWidgets.QMainWindow):
         elif action == "RGB Toggle":
             pass
 
-        # STAGE CHANGE
-        self.staging_manager.stage_change(self.current_edit_key, action, params)
-        
+        # STAGE CHANGE (skip if nothing actually changed)
+        effective = self.staging_manager.get_effective_state(self.current_edit_key)
+        if effective is None or effective.get("action") != action or effective.get("params") != params:
+            self.staging_manager.stage_change(self.current_edit_key, action, params)
+
         # UPDATE UI
         self._update_staged_visuals()
         
@@ -1899,21 +2132,41 @@ class MainWindow(QtWidgets.QMainWindow):
                 return self.parent._build_packets_for_key(key, action, params)
 
         try:
-            device = vp.VenusDevice(self.device_path)
+            device = dd.create_device(self.device_type, self.device_path)
             device.open()
-            
+
+            # Holtek: enter write mode before sending packets
+            if self.device_type == 'holtek':
+                device.enter_write_mode()
+
             builder = PacketBuilder(self)
             controller = TransactionController(device, builder, logger=self._log)
-            
+
             # Progress dialog
             progress = QtWidgets.QProgressDialog("Applying changes...", "Cancel", 0, 0, self)
             progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             progress.show()
-            
+
             success = controller.execute_transaction(self.staging_manager)
-            
+
+            # Holtek: commit button writes and reset device to reload
+            if self.device_type == 'holtek' and success:
+                progress.setLabelText("Restarting device, please wait...")
+                progress.setCancelButton(None)
+                QtWidgets.QApplication.processEvents()
+                device.commit_writes(categories=0x02)  # Button category + reset
+                # Device handle is dead after reset — close may fail, that's OK
+                try:
+                    device.close()
+                except Exception:
+                    pass
+                device = None
+                self._holtek_reconnect()
+
             progress.close()
-            device.close()
+
+            if device:
+                device.close()
             
             if success:
                 # Update local authoritative state
@@ -1939,6 +2192,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _build_packets_for_key(self, key: str, action: str, params: dict) -> list[bytes]:
         """Helper to build packets for a single key binding."""
+        # Holtek: use holtek_protocol's packet builder
+        if self.device_type == 'holtek':
+            btn_profile = self.active_button_profiles.get(key)
+            if btn_profile is None:
+                raise ValueError(f"Unknown button: {key}")
+            return hp.build_write_packets(btn_profile.index, action, params,
+                                          profile=self.holtek_profile)
+
         reports = []
         # Resolve addresses
         # Note: This logic duplicates _sync_all_buttons. Should eventually replace it.
@@ -2125,17 +2386,24 @@ class MainWindow(QtWidgets.QMainWindow):
         b = self.rgb_current_color.blue()
         mode = self.rgb_mode.currentData()
         brightness = self.rgb_brightness.value()
-        
+
+        if self.device_type == 'holtek':
+            return self._apply_rgb_holtek(r, g, b, mode, brightness)
+
         rgb_packet = vp.build_rgb(r, g, b, mode, brightness)
         # Sequence based on confirmed captures: 03 (Handshake), [RGB Data], 04 (Commit)
         reports = [vp.build_simple(0x03), rgb_packet, vp.build_simple(0x04)]
-        
+
         mode_name = self.rgb_mode.currentText()
         self._send_reports(reports, f"RGB Custom: #{r:02x}{g:02x}{b:02x} {mode_name} {brightness}%")
 
 
     def _apply_polling_rate(self) -> None:
         rate = self.polling_select.currentData()
+
+        if self.device_type == 'holtek':
+            return self._apply_polling_holtek(rate)
+
         payload = vp.POLLING_RATE_PAYLOADS[rate]
         reports = [vp.build_simple(0x04), vp.build_simple(0x03), vp.build_report(0x07, payload)]
         self._send_reports(reports, f"Polling {rate} Hz")
@@ -2157,6 +2425,9 @@ class MainWindow(QtWidgets.QMainWindow):
             tweak_spin.blockSignals(False)
 
     def _apply_dpi(self) -> None:
+        if self.device_type == 'holtek':
+            return self._apply_dpi_holtek()
+
         reports = [vp.build_simple(0x03)]
         for slot, (_, _, value_spin, tweak_spin) in enumerate(self.dpi_rows):
             value = value_spin.value()
@@ -2205,6 +2476,147 @@ class MainWindow(QtWidgets.QMainWindow):
         dpi_spin.blockSignals(False)
         tweak_spin.blockSignals(False)
 
+    def _on_profile_changed(self, index: int) -> None:
+        """Handle profile selector change — re-read settings for the new profile."""
+        if index < 0:
+            return
+        self.holtek_profile = self.profile_combo.currentData()
+        if self.holtek_profile is None:
+            self.holtek_profile = 0
+        self._log(f"Profile switched to {self.holtek_profile + 1}")
+
+        # Discard any staged changes (they belong to the previous profile)
+        if self.staging_manager.has_changes():
+            self.staging_manager.clear_stage()
+
+        # Re-read settings from device for the newly selected profile
+        if self.device_path and self.device_type == 'holtek':
+            self._read_settings_holtek(silent=True)
+
+    def _holtek_reconnect(self) -> None:
+        """Wait for Holtek device to reconnect after reset and update path.
+
+        Uses processEvents during the wait so the GUI stays responsive and
+        does not interfere with USB re-enumeration.
+        """
+        self._log("  Waiting for device to reconnect...")
+        # Initial wait — device needs time to fully disconnect before re-enumerating
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            QtWidgets.QApplication.processEvents()
+            time.sleep(0.1)
+
+        # Poll for reconnection
+        deadline = time.time() + 8.0
+        while time.time() < deadline:
+            new_path = hp.find_device_path()
+            if new_path:
+                self.device_path = new_path
+                self._log(f"  Device reconnected: {new_path}")
+                return
+            QtWidgets.QApplication.processEvents()
+            time.sleep(0.3)
+
+        self._log("  Warning: device did not reconnect within timeout")
+
+    def _apply_rgb_holtek(self, r: int, g: int, b: int, mode: int, brightness: int) -> None:
+        """Apply RGB settings on Holtek device."""
+        if not self._require_device():
+            return
+        device = None
+        progress = QtWidgets.QProgressDialog("Applying lighting...", None, 0, 0, self)
+        progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        progress.show()
+        QtWidgets.QApplication.processEvents()
+        try:
+            device = hp.HoltekDevice(self.device_path)
+            device.open()
+            device.enter_write_mode()
+            profile = self.holtek_profile
+            packets = hp.build_led_packets(r, g, b, mode, brightness, profile=profile)
+            for pkt in packets:
+                device.send_feature(pkt)
+                time.sleep(0.008)
+            # Commit LED and reset device to reload settings from flash
+            progress.setLabelText("Restarting device, please wait...")
+            QtWidgets.QApplication.processEvents()
+            device.commit_writes(categories=0x08)
+            # Device handle is dead after reset — close may fail
+            try:
+                device.close()
+            except Exception:
+                pass
+            device = None
+            mode_name = self.rgb_mode.currentText()
+            self._log(f"Holtek RGB (profile {profile + 1}): #{r:02x}{g:02x}{b:02x} {mode_name} {brightness}%")
+            # Wait for device to reconnect after reset
+            self._holtek_reconnect()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "RGB failed", str(exc))
+        finally:
+            progress.close()
+            if device:
+                device.close()
+
+    def _apply_polling_holtek(self, rate: int) -> None:
+        """Apply polling rate on Holtek device using F5 command."""
+        if not self._require_device():
+            return
+        device = None
+        try:
+            device = hp.HoltekDevice(self.device_path)
+            device.open()
+            device.set_polling_rate(rate)
+            self._log(f"Holtek Polling: {rate} Hz")
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "Polling rate failed", str(exc))
+        finally:
+            if device:
+                device.close()
+
+    def _apply_dpi_holtek(self) -> None:
+        """Apply DPI settings on Holtek device."""
+        if not self._require_device():
+            return
+        device = None
+        progress = QtWidgets.QProgressDialog("Applying DPI...", None, 0, 0, self)
+        progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        progress.show()
+        QtWidgets.QApplication.processEvents()
+        try:
+            device = hp.HoltekDevice(self.device_path)
+            device.open()
+            device.enter_write_mode()
+            # Collect DPI values from the UI (dpi_spin = actual DPI in CPI)
+            dpi_values = []
+            for _, dpi_spin, _, _ in self.dpi_rows:
+                dpi_values.append(dpi_spin.value())
+            # Write DPI to the selected profile only
+            profile = self.holtek_profile
+            packets = hp.build_dpi_packets(dpi_values, profile=profile)
+            for pkt in packets:
+                device.send_feature(pkt)
+                time.sleep(0.008)
+            # Commit DPI and reset device to reload settings from flash
+            progress.setLabelText("Restarting device, please wait...")
+            QtWidgets.QApplication.processEvents()
+            device.commit_writes(categories=0x04)
+            # Device handle is dead after reset — close may fail
+            try:
+                device.close()
+            except Exception:
+                pass
+            device = None
+            self._log(f"Holtek DPI (profile {profile + 1}): {dpi_values}")
+            # Wait for device to reconnect after reset
+            self._holtek_reconnect()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "DPI failed", str(exc))
+        finally:
+            progress.close()
+            if device:
+                device.close()
+
     def _send_built_report(self) -> None:
         if not self._require_device():
             return
@@ -2236,14 +2648,20 @@ class MainWindow(QtWidgets.QMainWindow):
     def _factory_reset(self) -> None:
         if not self._require_device():
             return
-        
+
+        if self.device_type == 'holtek':
+            QtWidgets.QMessageBox.information(self, "Not Supported",
+                "Factory reset is not yet supported for the Holtek Venus MMO.\n"
+                "Please use the Windows software for factory reset.")
+            return
+
         reply = QtWidgets.QMessageBox.question(
-            self, 
-            "Confirm Reset", 
+            self,
+            "Confirm Reset",
             "Are you sure you want to reset the device to factory defaults?\nThis will clear all custom button mappings, macros, and RGB settings.",
             QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No
         )
-        
+
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self._send_reports([vp.build_simple(0x09)], "Factory reset")
             QtWidgets.QMessageBox.information(self, "Reset Complete", "Factory reset command sent.")
@@ -2269,7 +2687,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _read_settings(self) -> None:
         if not self._require_device(auto_mode=True):
             return
-        
+
+        if self.device_type == 'holtek':
+            return self._read_settings_holtek()
+
         self._log("--- Reading from Device ---")
         device = None
         try:
@@ -2551,9 +2972,102 @@ class MainWindow(QtWidgets.QMainWindow):
             if device:
                 device.close()
 
+    def _read_settings_holtek(self, silent: bool = False) -> None:
+        """Read settings from Holtek Venus MMO device.
+
+        Args:
+            silent: If True, suppress the success message box (used during profile switch).
+        """
+        profile = self.holtek_profile
+        self._log(f"--- Reading from Holtek Device (Profile {profile + 1}) ---")
+        device = None
+        try:
+            device = hp.HoltekDevice(self.device_path)
+            device.open()
+
+            config = hp.read_all_config(device, profile=profile)
+            buttons = config['buttons']
+
+            self._log(f"  Read {len(buttons)} button entries from device")
+
+            # Parse button assignments into GUI format
+            self.button_assignments = {}
+            for btn_info in buttons:
+                idx = btn_info['index']
+                btn_key = f"Button {idx + 1}"
+                if btn_key not in self.active_button_profiles:
+                    continue
+
+                action, params = hp.button_action_to_gui(btn_info['type'], btn_info['code'])
+                self.button_assignments[btn_key] = {"action": action, "params": params}
+                self._log(f"  {btn_key}: {action} {params}")
+
+            # Fill missing buttons with Disabled
+            for btn_key in self.active_button_profiles:
+                if btn_key not in self.button_assignments:
+                    self.button_assignments[btn_key] = {"action": "Disabled", "params": {}}
+
+            # Load base state into staging manager
+            self.staging_manager.load_base_state(self.button_assignments)
+            self._update_staged_visuals()
+
+            # Update DPI spinboxes from per-profile values
+            dpi_stages = config.get('dpi_stages', [])
+            if dpi_stages:
+                self._log(f"  DPI stages: {dpi_stages}")
+                for i, dpi_val in enumerate(dpi_stages):
+                    if i < len(self.dpi_rows):
+                        _, dpi_spin, value_spin, tweak_spin = self.dpi_rows[i]
+                        dpi_spin.blockSignals(True)
+                        dpi_spin.setValue(dpi_val)
+                        dpi_spin.blockSignals(False)
+
+            # Update RGB color preview from per-profile LED settings
+            # Note: only update the color swatch, NOT mode/brightness — the Holtek
+            # factory defaults (mode=3 cycling, brightness=5) differ from the working
+            # tested values (mode=1 solid, brightness=100). Overriding the mode combo
+            # would cause "Apply Lighting" to send mode=3, which cycles colors instead
+            # of showing the user's chosen solid color.
+            led = config.get('led', {})
+            if led:
+                r, g, b = led.get('r', 0), led.get('g', 0), led.get('b', 0)
+                mode = led.get('mode', 3)
+                brightness = led.get('brightness', 5)
+                self._log(f"  LED: #{r:02x}{g:02x}{b:02x} mode={mode} brightness={brightness}")
+                self.rgb_current_color = QtGui.QColor(r, g, b)
+                if hasattr(self, 'rgb_color_button'):
+                    color = self.rgb_current_color
+                    self.rgb_color_button.setStyleSheet(
+                        f"background-color: {color.name()}; "
+                        f"color: {'white' if color.lightness() < 128 else 'black'}; "
+                        f"font-weight: bold;")
+
+            # Log raw data for debugging
+            dpi_raw = config.get('dpi_raw', b'')
+            if dpi_raw:
+                self._log(f"  DPI raw: {dpi_raw.hex()}")
+            led_raw = config.get('led_raw', b'')
+            if led_raw:
+                self._log(f"  LED raw: {led_raw.hex()}")
+
+            self._log(f"--- Done Reading Holtek (Profile {profile + 1}) ---")
+            if not silent:
+                QtWidgets.QMessageBox.information(self, "Read Success", "Holtek configuration successfully read from device.")
+
+        except Exception as e:
+            self._log(f"Error reading Holtek configuration: {e}")
+            QtWidgets.QMessageBox.critical(self, "Read Error", str(e))
+        finally:
+            if device:
+                device.close()
+
     def _export_profile(self) -> None:
         """Dump device memory to a file."""
         if not self._require_device():
+            return
+        if self.device_type == 'holtek':
+            QtWidgets.QMessageBox.information(self, "Not Supported",
+                "Profile export is not yet supported for the Holtek Venus MMO.")
             return
             
         fname, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save Profile", "profile.bin", "Binary Files (*.bin)")
@@ -2595,6 +3109,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _import_profile(self) -> None:
         """Load profile from file and write to device."""
         if not self._require_device():
+            return
+        if self.device_type == 'holtek':
+            QtWidgets.QMessageBox.information(self, "Not Supported",
+                "Profile import is not yet supported for the Holtek Venus MMO.")
             return
             
         fname, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Open Profile", "", "Binary Files (*.bin)")
@@ -2670,9 +3188,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._read_settings()
 
     def _initialize_default_assignments(self) -> None:
-
         """Initialize assignments with Disabled for all known buttons."""
-        for button_key in vp.BUTTON_PROFILES.keys():
+        for button_key in self.active_button_profiles.keys():
             self.button_assignments[button_key] = {"action": "Disabled", "params": {}}
             
     def _update_all_ui_from_assignments(self) -> None:

--- a/venus_protocol.py
+++ b/venus_protocol.py
@@ -389,9 +389,11 @@ HID_KEY_USAGE = {
     "Keypad 4": 0x5C, "Keypad 5": 0x5D, "Keypad 6": 0x5E,
     "Keypad 7": 0x5F, "Keypad 8": 0x60, "Keypad 9": 0x61,
     "Keypad 0": 0x62,
-    # Modifiers (for macro support)
-    # Note: Shift uses 0x20 in macro events, NOT 0x02 (which is the HID modifier bit)
-    "Shift": 0x20,  # Left Shift for macro events
+    # Modifier keys (standalone HID Usage Table 0xE0-0xE7)
+    "Left Ctrl": 0xE0, "Left Shift": 0xE1, "Left Alt": 0xE2, "Left GUI": 0xE3,
+    "Right Ctrl": 0xE4, "Right Shift": 0xE5, "Right Alt": 0xE6, "Right GUI": 0xE7,
+    # Legacy alias for macro events (uses different code)
+    "Shift": 0x20,
 }
 
 # USB HID Consumer Page codes (for media keys)
@@ -1060,33 +1062,55 @@ def _device_sort_key(info: DeviceInfo) -> tuple[int, int, str]:
     product_lower = info.product.lower()
     # Check string OR explicit PID for receiver
     is_receiver = "receiver" in product_lower or info.product_id == 0xFA07
-    
-    if info.interface_number == 1:
-        interface_rank = 0
-    elif info.interface_number == 0:
-        interface_rank = 1
+
+    # Holtek devices (VID 0x04D9) use interface 2 for config
+    is_holtek = info.vendor_id == 0x04D9
+
+    if is_holtek:
+        if info.interface_number == 2:
+            interface_rank = 0
+        else:
+            interface_rank = 2
     else:
-        interface_rank = 2
+        if info.interface_number == 1:
+            interface_rank = 0
+        elif info.interface_number == 0:
+            interface_rank = 1
+        else:
+            interface_rank = 2
     return (1 if is_receiver else 0, interface_rank, info.product)
 
 
 def list_devices(exclude_receivers: bool = False) -> list[DeviceInfo]:
     devices = []
     found = []
-    # First, try to open devices directly by VID/PID.
+    found_by_enum = set()  # Track (vid, pid) combos found via enumeration
+
+    # Try enumeration first to get full details (path, interface number)
+    try:
+        for vid in VENDOR_IDS:
+            devs = hid.enumerate(vid, 0)
+            for d in devs:
+                if d['product_id'] in PRODUCT_IDS:
+                    found.append(d)
+                    found_by_enum.add((d['vendor_id'], d['product_id']))
+    except:
+        pass
+
+    # Fallback: try direct open for VID/PIDs not found by enumeration.
     # This is necessary for some systems (e.g., macOS) where hid.enumerate()
     # might not return all necessary details or might fail for certain devices.
     for vid in VENDOR_IDS:
         for pid in PRODUCT_IDS:
+            if (vid, pid) in found_by_enum:
+                continue
             try:
-                # Open with path=None to find first matching device
                 h = hid.device()
                 h.open(vid, pid)
-                # If success, we found one
                 found.append({
                     'vendor_id': vid,
                     'product_id': pid,
-                    'path': b"Unknown (hidapi open)",  # hidapi.device() obj doesn't expose path easily after open
+                    'path': b"Unknown (hidapi open)",
                     'interface_number': -1
                 })
                 h.close()
@@ -1094,41 +1118,22 @@ def list_devices(exclude_receivers: bool = False) -> list[DeviceInfo]:
                 continue
             except Exception:
                 continue
-    
-    # Also try enumeration to get more details if possible
-    try:
-        for vid in VENDOR_IDS:
-            devs = hid.enumerate(vid, 0)
-            for d in devs:
-                if d['product_id'] in PRODUCT_IDS:
-                     # Check if already found by open check (deduplicate loosely)
-                    already = False
-                    for f in found:
-                        if f['vendor_id'] == d['vendor_id'] and f['product_id'] == d['product_id']:
-                             f['path'] = d['path']
-                             f['interface_number'] = d['interface_number']
-                             already = True
-                             break
-                    if not already:
-                        found.append(d)
-    except:
-        pass
 
     seen_paths = set()
-    for item in found: # Iterate through the combined list of found devices
+    for item in found:
         if item["product_id"] not in PRODUCT_IDS:
             continue
-        
+
         product = item.get("product_string") or "Unknown"
-        
+
         # Filter out "Wireless Receiver" only when explicitly requested.
         if exclude_receivers and "receiver" in product.lower():
             continue
-        
-        # Prefer "Dual Mode Mouse" on Interface 0 (the actual configurable device)
-        # Also accept Interface 1 for compatibility with some firmware versions
+
+        # Accept interfaces 0, 1, 2 (generic HID config interface on Holtek variants)
+        # and -1 for fallback direct-open entries
         interface = item.get("interface_number", -1)
-        if interface not in [0, 1]:
+        if interface not in [-1, 0, 1, 2]:
             continue
         
         path_str = item["path"].decode() if isinstance(item["path"], bytes) else item["path"]


### PR DESCRIPTION
## Summary

Adds full protocol implementation and GUI integration for the **Holtek-based Venus MMO mouse** (VID:PID `04D9:FC55`), which uses a completely different USB HID protocol from the Venus Pro (`25A7:FA07`/`FA08`).

All existing Venus Pro functionality is unchanged — device type is detected automatically from VID/PID on connect.

## What's new

### Protocol layer (`holtek_protocol.py`)
- Complete reverse-engineered protocol for the Holtek variant
- Uses HID Interface 2 with Report ID `0x02` (16B) and `0x03` (64B) feature reports — **no checksums**
- Commands: `F1` (write control / device reset), `F2` (read), `F3` (write data), `F5` (polling rate)
- Write sequence: `enter_write` → `F3` data → category commit → `exit_write` → device reset (USB disconnect/reconnect)
- `HoltekDevice` class with 20-button profiles, per-profile DPI/LED/button bindings

### Device detection (`device_driver.py`)
- Auto-detection from VID/PID with factory pattern for creating correct device instances
- Transparent to the GUI — same interface for both device variants

### GUI enhancements (`venus_gui.py`)
- **Profile selector**: global Profile 1–5 selector for Holtek devices with per-profile settings
- **Custom KeyCaptureEdit widget**: distinguishes numpad keys (Keypad 1 vs 1) and left/right modifiers (Left Shift vs Right Shift) via native scan codes
- **Standalone modifier keys**: Shift, Ctrl, Alt, GUI bindable as actions with proper HID usage codes (`0xE0`–`0xE7`)
- Auto-staged binding changes on editor interaction
- Modal progress dialog during device reset/reconnect
- Dynamic button table (16 or 20 buttons depending on device)

### Packaging & install
- `install.sh`, `PKGBUILD`, and udev rules updated for Holtek VID/PID (`04D9:FC55`)
- New `packaging/linux/99-venus-pro.rules` udev rules file

## Protocol differences from Venus Pro

| Aspect | Venus Pro (25A7) | Holtek Venus MMO (04D9) |
|--------|-----------------|------------------------|
| Interface | HID (default) | HID Interface 2 (Usage Page 0xFFA0) |
| Report IDs | 0x08 (17B) | 0x02 (16B) / 0x03 (64B) |
| Checksums | Yes (base 0x55) | None |
| Commands | 0x03–0x09 | 0xF1–0xF5 |
| Buttons | 16 | 20 |
| Profiles | 1 | 5 (hardware) |
| Write commit | Single | Per-category (buttons=0x02, DPI=0x04, LED=0x08) |
| Post-write | Immediate | Device reset required |

## Test plan

- [x] Verified read/write cycle on physical Holtek device (04D9:FC55)
- [x] Button remapping persists across device resets
- [x] DPI and LED changes apply correctly per profile
- [x] Venus Pro device detection and functionality unaffected
- [ ] Test on additional Holtek Venus MMO units if available