### PR TITLE
Reverse-engineer Venus protocol and add battery monitoring

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,21 +1,19 @@
 pkgbase = venusprolinux-git
-	pkgdesc = Linux configuration utility for the UtechSmart Venus Pro MMO mouse
-	pkgver = 0.0.0
+	pkgdesc = Linux configuration and battery utility for UtechSmart Venus mice
+	pkgver = 0.2.1.r7.g2b67745
 	pkgrel = 1
 	url = https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility
+	install = venusprolinux.install
 	arch = any
 	license = MIT
 	makedepends = git
 	depends = python
 	depends = python-hidapi
 	depends = python-pyqt6
-	optdepends = python-evdev: software macro playback
-	optdepends = python-pyusb: magic unlock helper
+	optdepends = python-pyusb: USB-bus diagnostics and recovery
 	provides = venusprolinux
 	conflicts = venusprolinux
-	source = git+https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git
-	source = 99-venus-pro.rules
-	sha256sums = SKIP
+	source = venusprolinux::git+https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git
 	sha256sums = SKIP
 
 pkgname = venusprolinux-git

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,4 +1,5 @@
-# Local packaging copy. The AUR-facing PKGBUILD lives at the repository root.
+# Maintainer: Es00bac <cabewse at gmail dot com>
+
 pkgname=venusprolinux-git
 pkgver=0.2.1.r7.g2b67745
 pkgrel=1
@@ -11,6 +12,7 @@ makedepends=('git')
 optdepends=('python-pyusb: USB-bus diagnostics and recovery')
 provides=('venusprolinux')
 conflicts=('venusprolinux')
+install=venusprolinux.install
 source=('venusprolinux::git+https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git')
 sha256sums=('SKIP')
 
@@ -21,11 +23,14 @@ pkgver() {
 
 package() {
     cd "$srcdir/venusprolinux"
+
     install -d "$pkgdir/usr/share/venusprolinux"
     install -m644 venus_gui.py venus_protocol.py holtek_protocol.py \
         device_driver.py staging_manager.py transaction_controller.py \
         mouseimg.png icon.png "$pkgdir/usr/share/venusprolinux/"
-    install -Dm755 packaging/linux/venusprolinux "$pkgdir/usr/bin/venusprolinux"
+
+    install -Dm755 packaging/linux/venusprolinux \
+        "$pkgdir/usr/bin/venusprolinux"
     install -Dm644 packaging/linux/venusprolinux.desktop \
         "$pkgdir/usr/share/applications/venusprolinux.desktop"
     install -Dm644 com.github.es00bac.venusprolinux.appdata.xml \
@@ -34,5 +39,6 @@ package() {
         "$pkgdir/usr/share/icons/hicolor/512x512/apps/venusprolinux.png"
     install -Dm644 packaging/linux/99-venus-pro.rules \
         "$pkgdir/usr/lib/udev/rules.d/99-venus-pro.rules"
-    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 LICENSE \
+        "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,257 +1,388 @@
-# UtechSmart Venus Pro USB HID Protocol
+# UtechSmart Venus mouse protocols
 
-This is the single source of truth for the Venus Pro configuration protocol, derived
-from captures and the current `venus_protocol.py` implementation. Wired and wireless
-mode share the same configuration format and commands.
+This document separates two unrelated protocols that are sold under similar
+Venus names. It is derived from the repository's USBPcap traces, EEPROM dumps,
+live Linux USB descriptors, and decompilation of the bundled Windows utility.
 
-## Device IDs and Interfaces
+Evidence labels used below:
 
-- **Vendor IDs**: `0x25A7`, `0x04D9`
-- **Product IDs**:
-  - `0xFA07` = Venus Pro Wireless Receiver (2.4GHz dongle)
-  - `0xFA08` = Venus Pro Wired (dual mode mouse via USB)
-  - `0xFC55` = Venus MMO Wired
+- **Capture** — directly present in USB traffic.
+- **Binary** — implemented by the vendor utility.
+- **Descriptor** — declared by the live USB/HID descriptor.
+- **Live** — reproduced with a read-only query against the connected device.
+- **Inference** — consistent with the evidence, but its user-facing meaning is
+  not completely proved.
 
-- Configuration is sent as HID **Feature Reports** on the vendor interface.
-  - Interface `1` is the preferred config interface.
-  - Interface `0` is accepted on some firmware; the code will try both.
+## Protocol families
 
-## Report Format
+| USB ID | Controller/family | Config interface | Protocol |
+|---|---|---:|---|
+| `25a7:fa07` | Areson/Compx wireless receiver | 1 | 17-byte reports described below |
+| `25a7:fa08` | Areson/Compx wired connection | 1 | Same Areson protocol |
+| `04d9:fc55` | Holtek wired Venus MMO | 2 | Separate `F1/F2/F3/F5` protocol |
 
-All configuration packets are 17 bytes:
+Do not send Areson packets to the Holtek device. The Holtek implementation and
+its five-profile memory map are documented in `holtek_protocol.py`.
 
+## Areson transport (`25a7:fa07` and `25a7:fa08`)
+
+The device has separate boot-mouse and keyboard/vendor HID interfaces. The
+configuration channel is interface 1. On the live `fa07` descriptor:
+
+- feature report `0x08` is 17 bytes and belongs to vendor usage page `0xff02`;
+- interrupt-IN report `0x09` is 17 bytes and belongs to vendor usage page
+  `0xff01`;
+- responses arrive on endpoint `0x82`.
+
+This is a request/response channel, not one bidirectional report. Requests are
+sent with HID `SET_REPORT(Feature)` (`wValue=0x0308`, `wIndex=1`) and responses
+arrive asynchronously as interrupt report `0x09`. **Descriptor, Capture**
+
+### Packet format
+
+Every request and response is exactly 17 bytes:
+
+```text
+00     report ID: 08 request, 09 response
+01     command
+02     reserved (00 in every captured protocol packet)
+03-04  16-bit address, big-endian (commands 07/08)
+05     data length
+06-15  up to 10 data bytes, zero-padded on requests
+16     checksum
 ```
-Byte 0  : Report ID (0x08)
-Byte 1  : Command ID
-Byte 2-15 : Payload (14 bytes)
-Byte 16 : Checksum
-```
 
-Checksum calculation (sum of bytes 0..15 must equal 0x55):
+The checksum invariant is:
+
 ```python
-checksum = (0x55 - sum(bytes[0:16])) & 0xFF
+sum(packet) & 0xff == 0x55
+checksum = (0x55 - sum(packet[0:16])) & 0xff
 ```
 
-Responses arrive as Report ID `0x09`, echoing the command. For reads (`0x08`),
-the response payload includes `[page][offset][len][data...]`.
+The old documentation called bytes 3 and 4 “profile page” and “offset.” That
+representation can construct the bytes, but the vendor binary treats them as
+one 16-bit EEPROM address. The Areson model configuration exposes one hardware
+profile (`ShowProSw=0`); adding `0x40/0x80/0xc0` to page numbers writes unrelated
+high EEPROM regions. **Capture, Binary**
 
-## Command Summary
+### Commands
 
-| Cmd | Description |
-|-----|-------------|
-| `0x03` | Handshake / ready |
-| `0x04` | Prepare / commit (sent before and after write sequences) |
-| `0x07` | Write flash (page/offset addressing) |
-| `0x08` | Read flash |
-| `0x09` | Reset to defaults |
-| `0x4D`, `0x01` | Magic unlock sequence for macro/page-3 writes |
+| Command | Request | Response and meaning | Evidence |
+|---:|---|---|---|
+| `01` | length 4, random challenge | length 4, transformed challenge | Capture, Binary |
+| `02` | length 1, data `01` | echoes `01`; enables/announces driver state | Capture; semantic name is Inference |
+| `03` | empty | length 1, data `01`; ready/begin-operation handshake | Capture, Binary |
+| `04` | empty | length 2: battery step, cable flag | Capture, Binary |
+| `07` | address, length, data | acknowledges/echoes the write | Capture, Binary |
+| `08` | address and length | returns length and EEPROM data | Capture, Binary |
+| `09` | empty | factory reset; erases settings and macros | Capture, Binary |
 
-Typical write flow:
-1. `0x03` (handshake)
-2. One or more `0x07` writes
-3. `0x04` (commit)
+There is no command `0x4d` in any supplied capture. It was an artifact of the
+old implementation. Likewise, command `0x04` is not prepare/commit. EEPROM
+writes persist after their `0x07` acknowledgement; the Windows utility does not
+send a commit after each write group. **Capture, Binary**
 
-## Addressing and Profiles
+#### Challenge response (`01`)
 
-Flash is 256 pages × 256 bytes. Write/read payloads use:
-```
-[0x00, page, offset, length, data...]
-```
+For challenge bytes `a,b,c,d`, the expected response is:
 
-For `0x07` writes, `length` is typically ≤ 10 bytes; larger writes require multiple packets.
-
-**Profile Base Offsets** (add to page number for profile-specific data):
-- Profile 1: `0x00`
-- Profile 2: `0x40`
-- Profile 3: `0x80`
-- Profile 4: `0xC0`
-
-## Button Map
-
-Each button has:
-- **Keyboard definition slot**: `code_hi` (page), `code_lo` (offset within page)
-- **Apply slot**: `apply_offset` in Page `0x00 + profile_base`
-
-| Button | Label | code_hi | code_lo | apply_offset |
-|--------|-------|---------|---------|--------------|
-| 1 | Side Button 1 | 0x01 | 0x00 | 0x60 |
-| 2 | Side Button 2 | 0x01 | 0x20 | 0x64 |
-| 3 | Side Button 3 | 0x01 | 0x40 | 0x68 |
-| 4 | Side Button 4 | 0x01 | 0x60 | 0x6C |
-| 5 | Side Button 5 | 0x01 | 0x80 | 0x70 |
-| 6 | Side Button 6 | 0x01 | 0xA0 | 0x74 |
-| 7 | Side Button 7 | 0x02 | 0x00 | 0x80 |
-| 8 | Side Button 8 | 0x02 | 0x20 | 0x84 |
-| 9 | Side Button 9 | 0x02 | 0x80 | 0x90 |
-| 10 | Side Button 10 | 0x02 | 0xA0 | 0x94 |
-| 11 | Side Button 11 | 0x02 | 0xC0 | 0x98 |
-| 12 | Side Button 12 | 0x02 | 0xE0 | 0x9C |
-| 13 | Fire Key | 0x02 | 0x60 | 0x8C |
-| 14 | Left Mouse Button | 0x01 | 0xE0 | 0x7C |
-| 15 | Middle Mouse Button | 0x02 | 0x40 | 0x88 |
-| 16 | Right Mouse Button | 0x01 | 0xC0 | 0x78 |
-
-## Button Type Codes
-
-| Type | Value | Description |
-|------|-------|-------------|
-| Disabled | `0x00` | Button does nothing |
-| Mouse | `0x01` | Mouse button (d1 = button mask) |
-| DPI Legacy | `0x02` | DPI control |
-| Special | `0x04` | Fire Key / Triple Click (d1 = delay, d2 = repeat) |
-| Keyboard | `0x05` | Standard keyboard key |
-| Macro | `0x06` | Macro (d1 = index, d2 = repeat mode) |
-| Poll Rate Toggle | `0x07` | Toggle polling rate |
-| RGB Toggle | `0x08` | Toggle RGB LED |
-
-**Mouse Button Masks (Type 0x01):**
-- `0x01` = Left Click
-- `0x02` = Right Click
-- `0x04` = Middle Click
-- `0x08` = Back
-- `0x10` = Forward
-
-## Keyboard Definition Slots
-
-Keyboard slots are stored at `code_hi + profile_base` page, `code_lo` offset, in 0x20-byte blocks.
-
-**Simple key (no modifiers):**
-```
-count = 2
-events: [0x81, key, 0x00] [0x41, key, 0x00]
-guard = (0x91 - (key * 2)) & 0xFF
+```text
+r0 = a + b + 5
+r1 = 2*b + c
+r2 = 3*c + d
+r3 = 4*d + a
 ```
 
-**Key with modifier:**
+All operations are modulo 256. Five independent captured challenge pairs match
+this formula. The old code replayed one pair and mislabeled it an unlock. The
+vendor utility generates each challenge byte in the range 1–100 and verifies
+the response. **Capture, Binary**
+
+#### Vendor startup sequence
+
+The Windows utility performs this non-destructive sequence:
+
+1. `03` ready
+2. `01` random challenge
+3. `08` read two bytes at `0x0004`
+4. `02` with data `01`
+5. configuration reads
+6. `04` status query
+
+Writing normally begins with `03`, followed by one or more `07` writes. Factory
+reset (`09`) is never part of session setup. **Capture, Binary**
+
+### Battery and connection status (`04`)
+
+The two response bytes are:
+
+```text
+data[0]  battery step, 0..10 (display as step * 10 percent)
+data[1]  0 = wireless path, 1 = USB cable/wired path
 ```
-count = 4
-events: [0x80, mod, 0x00] [0x81, key, 0x00] [0x40, mod, 0x00] [0x41, key, 0x00]
-guard = (0x91 - (key * 2) + 0x3A) & 0xFF
+
+Observed responses include `0a 00`, `0a 01`, `07 01`, and `06 00`. A direct
+Linux status query on the connected `25a7:fa07` also returned `06 00`. Capture
+filenames and connection state correlate the second byte with cable/wired
+operation. It should not be labeled “charging” unless charging is independently
+confirmed for a particular firmware. **Capture, Live; cable meaning is strong
+Inference**
+
+## Areson EEPROM map
+
+Only the following range is used by the vendor application:
+
+| Address | Size | Meaning | Confidence |
+|---:|---:|---|---|
+| `0000` | 2 | polling code + record checksum | Capture, Binary |
+| `0002` | 2 | enabled DPI-stage count + checksum | Binary; meaning confirmed by layout |
+| `0004` | 2 | active/default DPI stage record | Startup read; exact semantics Inference |
+| `0006-000b` | 6 | additional DPI state records | Unknown |
+| `000c-002b` | 32 | eight possible DPI records, four bytes each | Capture, Binary |
+| `002c-005f` | 52 | DPI colors and lighting configuration | Capture, Binary |
+| `0060-009f` | 64 | 16 button action records | Capture, Binary |
+| `0100-02ff` | 512 | 16 event-definition slots, `0x20` bytes each | Capture, Binary |
+| `0300-1aff` | 6144 | 16 macro slots, `0x180` bytes each | Capture, Binary |
+
+The remainder of 64 KiB dumps is predominantly erased `ff` data. Reading it is
+useful for research, but it is not evidence for extra Areson profiles.
+
+### Polling rate
+
+The two-byte record at `0x0000` is `[code, 0x55-code]`:
+
+| Rate | Code | Check byte |
+|---:|---:|---:|
+| 125 Hz | `08` | `4d` |
+| 250 Hz | `04` | `51` |
+| 500 Hz | `02` | `53` |
+| 1000 Hz | `01` | `54` |
+
+The 250/500/1000 writes are directly captured; `08` for 125 is present in the
+vendor binary's read/write conversion. The prior `04/02/01/00` table was shifted
+and treated a valid `01` code as 500 Hz. **Capture, Binary**
+
+### DPI records
+
+Eight four-byte slots start at `0x000c`:
+
+```text
+[x_raw, y_raw, sensor_flag, inner_checksum]
+sum(record) & 0xff == 0x55
 ```
 
-**Modifier Bit Flags:**
-- `0x01` = Ctrl
-- `0x02` = Shift
-- `0x04` = Alt
-- `0x08` = Win/GUI
+The bundled driver contains sensor-specific DPI lookup tables rather than one
+universal linear formula. Its configuration names sensor families `0x3325` and
+`0x3335`; the active choice is influenced by the device version/sensor nibble.
+Consequently, arbitrary raw-to-DPI interpolation should be described as an
+approximation. Exact captured/default anchors include:
 
-## Macro Storage
+```text
+default:  1000=0b, 2000=17, 4000=2f, 8000=5f, 10000=bd
+captured edits: 1600=12, 2400=1b, 4900=3a, 8900=6a
+```
 
-Macro slots are 384 bytes (0x180) each, starting at page `0x03`:
+The fifth edited filename is ambiguous (`1410` vs `14100`) and is not used as a
+conversion anchor. Raw X/Y and the record checksum are known; a complete
+per-sensor DPI table remains an open item. **Capture, Binary**
+
+### Button action table
+
+There are 16 records at `0x0060 + 4*index`. Every record is:
+
+```text
+[type, d1, d2, inner_checksum]
+inner_checksum = (0x55 - type - d1 - d2) & 0xff
+```
+
+Physical mapping:
+
+| Internal index | Address | Physical control |
+|---:|---:|---|
+| 0–5 | `0060-0074` | side buttons 1–6 |
+| 6 | `0078` | right mouse button |
+| 7 | `007c` | left mouse button |
+| 8–9 | `0080-0084` | side buttons 7–8 |
+| 10 | `0088` | middle mouse button |
+| 11 | `008c` | fire button |
+| 12–15 | `0090-009c` | side buttons 9–12 |
+
+The physical top DPI buttons are absent from this Areson table. No capture or
+vendor configuration entry addresses them, so they appear firmware-fixed on
+`25a7:fa07/fa08`. The separate Holtek map does contain DPI Up and DPI Down and
+allows them to be assigned keyboard actions. **Capture, Binary**
+
+Action types:
+
+| Type | d1 | d2 | Meaning |
+|---:|---|---|---|
+| `00` | 0 | 0 | disabled |
+| `01` | mouse mask | 0 | native mouse button |
+| `02` | 1 loop, 2 up, 3 down | 0 | DPI control |
+| `04` | delay ms | repeat count | repeated left click/fire |
+| `05` | 0 | 0 | execute this index's event-definition slot |
+| `06` | macro slot 0–15 | repeat/mode | execute hardware macro |
+| `07` | 0 | 0 | cycle polling rate |
+| `08` | 0 | 0 | toggle lighting |
+| `09` | 0 | 0 | profile switch in generic vendor code; hidden here |
+
+Mouse masks are `01` left, `02` right, `04` middle, `08` back, and `10`
+forward. Thus the exact left-click record is `01 01 00 53`, not one of the old
+guessed `f0/f1/f2` records. **Capture, Binary**
+
+### Event-definition slots
+
+Button index `i` has a `0x20`-byte definition block at:
+
+```text
+address = 0x0100 + i * 0x20
+```
+
+The block begins with an event count, followed by three-byte events and one
+inner checksum. Unused bytes remain `ff`:
+
+```text
+[count] [status, code_lo, code_hi] ... [checksum] [ff ...]
+sum(count through checksum) & 0xff == 0x55
+```
+
+Statuses:
+
+- `81` / `41`: keyboard usage down/up
+- `80` / `40`: modifier down/up; codes `01/02/04/08` are Ctrl/Shift/Alt/GUI
+- `82` / `42`: 16-bit Consumer Page usage down/up
+
+Each modifier is a separate event. For Ctrl+Shift+1, the vendor emits six
+events: Ctrl down, Shift down, 1 down, Ctrl up, Shift up, 1 up. A combined
+modifier bitmask in one event is not equivalent. **Capture, Binary**
+
+### Macros
+
+There are 16 slots:
+
+```text
+slot_address = 0x0300 + slot_index * 0x0180
+slot_size    = 384 bytes
+```
+
+Layout:
+
+| Offset | Size | Meaning |
+|---:|---:|---|
+| `00` | 1 | UTF-16LE name length in bytes |
+| `01-1e` | 30 | name, zero padded (15 UTF-16 code units) |
+| `1f` | 1 | event count |
+| `20...` | 5 each | macro events |
+| after events | 4 | `[checksum, 00, 00, 00]` |
+
+The apparent `00 03` before the checksum in many traces is the final event's
+big-endian 3 ms delay. It is not part of a six-byte terminator.
+
+Each event is:
+
+```text
+[status, code, 00, delay_hi, delay_lo]
+```
+
+The status high bits encode direction (`80` down, `40` up); the low three bits
+encode class:
+
+| Status | Class |
+|---:|---|
+| `80/40` | modifier |
+| `81/41` | keyboard |
+| `84/44` | mouse button |
+
+Mouse event codes use the same `01/02/04/08/10` button masks. The bundled UI
+enables the first three through `MacroHasMsKey=0x07`; the converter itself also
+recognizes back and forward. It rejects other event classes, and the fixed
+five-byte representation has no accepted relative-movement class. Native mouse
+clicks are therefore supported; mouse movement is not. **Binary; left/right/
+middle UI behavior corroborated by issue report**
+
+Terminator checksum:
+
 ```python
-slot_addr = 0x300 + (index * 0x180)
-page = slot_addr >> 8
-offset = slot_addr & 0xFF
+checksum = (0x55 - event_count - sum(serialized_events)) & 0xff
 ```
 
-**Macro Buffer Layout:**
-| Offset | Size | Description |
-|--------|------|-------------|
-| 0x00 | 1 | Name length (bytes, UTF-16LE) |
-| 0x01-0x1E | 30 | Name bytes (UTF-16LE, ~15 chars) |
-| 0x1F | 1 | Event count |
-| 0x20+ | 5 each | Events |
+A slot can hold at most 69 events (`32 + 69*5 + 4 = 381`). The vendor forces a
+minimum event delay of 3 ms during conversion. **Capture, Binary**
 
-**Event Format (5 bytes):**
-```
-[status] [keycode] [00] [delay_hi] [delay_lo]
-```
-- `0x81` = Key down
-- `0x41` = Key up
-- `0x80` = Modifier down
-- `0x40` = Modifier up
+Macro action repeat byte:
 
-**Macro Terminator (6 bytes):**
-```
-[00] [03] [checksum] [00] [00] [00]
-```
-Checksum: `(~sum(events) - event_count + 0x56) & 0xFF`
+- `01..fd`: repeat count
+- `fe`: repeat while the physical button is held
+- `ff`: toggle/continue until another activation
 
-**Macro Repeat Modes:**
-| Value | Mode |
-|-------|------|
-| `0x01` | Play once |
-| `0x02`-`0xFD` | Repeat N times |
-| `0xFE` | Repeat while held |
-| `0xFF` | Toggle on/off |
+### Lighting records
 
-## DPI Configuration
+The following write shapes are directly observed and are implemented:
 
-DPI uses linear interpolation between known reference points:
+- steady/neon: 8 bytes at `0x0054`, containing RGB + RGB checksum, mode + mode
+  checksum, and brightness + brightness checksum;
+- off: `00 55` at `0x0058`;
+- breathing/alternate effect: `03 52` at `0x005c`.
 
-| DPI | Value | Tweak |
-|-----|-------|-------|
-| 1000 | 0x0B | 0x3F |
-| 2000 | 0x17 | 0x27 |
-| 4000 | 0x2F | 0xF7 |
-| 8000 | 0x5F | 0x97 |
-| 10000 | 0xBD | 0xDB |
+All inner two-/four-/eight-byte records retain the `sum == 0x55` invariant.
+The generic vendor binary also contains “stream”/main-lighting branches, but
+this mouse's configuration hides some of them. Those branches should not be
+claimed as confirmed Areson features until a matching capture exists.
 
-**Tweak Calculation:**
-```python
-tweak = (0x55 - (value * 2)) & 0xFF
-```
+The lowest captured steady-light brightness pair is `01 54` (brightness byte
+plus its `0x55` complement). Battery LED mode uses that exact pair. Its
+application-level color mapping is full-saturation red at 0%, yellow at 50%,
+and green at 100%, linearly interpolated through orange/yellow-green. Because
+status command `04` reports only 11 levels, the physical LED has 11 gradient
+steps. The controller writes only when that level changes and restores the
+previous lighting on a normal exit; no volatile Areson LED command has been
+confirmed. **Capture; controller policy**
 
-**DPI Slot Addresses:**
-Five slots at page `0x00 + profile_base`, offsets `0x0C`, `0x10`, `0x14`, `0x18`, `0x1C`.
+## Holtek summary (`04d9:fc55`)
 
-## Polling Rate
+The Holtek device uses interface 2, report `02` (16 bytes) and report `03` (64
+bytes), with feature-report reads rather than Areson's interrupt response. Its
+commands are:
 
-Polling rate is stored at page `0x00 + profile_base`, offset `0x00`:
+- `f1` write control/commit categories
+- `f2` memory read
+- `f3` memory write
+- `f5` polling rate
 
-| Rate (Hz) | Code | Guard |
-|-----------|------|-------|
-| 125 | 0x04 | 0x51 |
-| 250 | 0x02 | 0x53 |
-| 500 | 0x01 | 0x54 |
-| 1000 | 0x00 | 0x55 |
+It has five real hardware profiles and a 20-entry button map. Entries 4 and 5
+(zero-based indices) are physical DPI Up and DPI Down, so those controls can be
+rebound. Areson profile bases, checksums, command `04`, and macro layout do not
+apply to it. See `holtek_protocol.py` for the complete implemented map.
 
-**Packet format:**
-```
-[00, 00, 00, 02, rate_code, rate_guard, 00...]
-```
+## Remaining unknowns
 
-## RGB / Lighting
+- Exact user-facing meaning of Areson records `0x0004..0x000b`.
+- Complete DPI lookup tables for every Areson sensor/version combination.
+- Whether the generic vendor “stream” lighting path is reachable on this exact
+  firmware.
+- Whether macro back/forward events are accepted by firmware as well as by the
+  vendor converter (left/right/middle are the supported UI subset).
 
-RGB uses different packet formats depending on mode:
+These are intentionally marked unknown rather than filled with guessed magic
+values.
 
-**Mode Constants:**
-| Mode | Value |
-|------|-------|
-| Off | `0x00` |
-| Steady | `0x01` |
-| Neon | `0x02` |
-| Breathing | `0x03` |
+## Reproducing the analysis
 
-**Steady/Neon (offset 0x54):**
-```
-[00, 00, 54, 08, R, G, B, ColorChk, Mode, 54, B1, B2, 00, 00]
-```
-- `ColorChk = (0x55 - (R + G + B)) & 0xFF`
-- `B1 = brightness * 3` (capped 1-255)
-- `B2 = (0x55 - B1) & 0xFF`
-- Mode: `0x01` for Steady, `0x02` for Neon
+`tools/decode_areson_pcap.py` decodes report framing, checksums, addresses, and
+known regions directly from the repository's USBPcap files. For example:
 
-**Breathing (offset 0x5C):**
-```
-[00, 00, 5C, 02, 03, 52, 00, 00, 00, 00, 00, 00, 00, 00]
-```
-(Fixed format, cycles through colors)
-
-**Off (offset 0x58):**
-```
-[00, 00, 58, 02, 00, 55, 00, 00, 00, 00, 00, 00, 00, 00]
+```bash
+python3 tools/decode_areson_pcap.py \
+  "usbcap/usb polling rate from 125 to 250 to 500 to 1000.pcapng" --hex
 ```
 
-## Media Key Codes
+The binary analysis used the bundled 32-bit
+`UtechSmart/Venus wireless/OemDrv.exe` (SHA-256
+`28bab71de7267c0872f8c54baeb14bfdae0859ee6dabf309067c95ae7ea3d8c8`). The
+Ghidra post-scripts `GhidraProtocolExport.java`, `GhidraDecompileRange.java`,
+and `GhidraDumpMemory.java` under `tools/` reproduce the string-xref,
+decompilation, and lookup-table extraction steps.
 
-Media keys use USB HID Consumer Page codes:
-
-| Function | Code |
-|----------|------|
-| Play/Pause | 0xCD |
-| Next Track | 0xB5 |
-| Prev Track | 0xB6 |
-| Mute | 0xE2 |
-| Volume Up | 0xE9 |
-| Volume Down | 0xEA |
+For live troubleshooting without EEPROM writes, `tools/diagnose_device.py`
+lists the chosen configuration interface. Its optional `--battery` flag sends
+only status command `0x04`.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,29 @@ It gives Linux users a practical way to manage bindings, macros, DPI profiles, p
 yay -S venusprolinux-git
 ```
 
-### Manual install
+The repository now contains a complete VCS `PKGBUILD`; it uses Arch's
+`python-pyqt6` and `python-hidapi` packages and does not build Python packages
+with pip.
+
+### Arch Linux (manual)
+
+Install the Python packages with pacman first. `cython` is included here for
+people who also experiment with the PyPI hidapi build; the packaged runtime
+does not otherwise need a compiler.
+
+```bash
+sudo pacman -S --needed cython python-pyqt6 python-hidapi
+git clone https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git
+cd UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility
+./install.sh
+```
+
+### Other distributions (manual)
 
 ```bash
 git clone https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility.git
 cd UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility
-pip install cython hidapi PyQt6
+python3 -m pip install --user hidapi PyQt6
 ./install.sh
 ```
 
@@ -59,6 +76,10 @@ If your device reports a different ID, verify support before assuming compatibil
 - **Button Remapping:** Configure all 16 buttons, including the 12-button side panel.
 - **Modifier Support:** Bind buttons to combinations such as `Ctrl+Shift+1` and `Alt+F1`.
 - **Macro Engine:** Visual macro editor to record and edit events with precise timing.
+- **Mouse Macro Events:** Add native left, right, and middle press/release events.
+- **Battery Tray Icon:** Shows battery level and cable state through Qt's desktop tray API.
+- **Battery-color Mouse LED:** Optional minimum-brightness green → yellow →
+  orange → red gauge, controlled by the app while it remains in the tray.
 - **RGB Lighting:** Full control over LED color, brightness, and effects such as Steady, Breathing, Neon, and Off.
 - **DPI Profiles:** Configure up to 5 DPI presets with customizable levels.
 - **Polling Rate:** Adjust USB polling rate between 125Hz and 1000Hz.
@@ -111,32 +132,70 @@ Diagnostic and recovery tools, including factory reset and debug logging for raw
 ## Requirements
 
 - **Python 3.8+**
-- **Cython**
 - **hidapi**
 - **PyQt6**
 
 Optional dependencies:
 
-- **python-evdev** — software macro playback
 - **python-pyusb** — advanced device management
 
 ## Installation notes
 
-### Safer non-root access with udev
+### Non-root access with udev
 
-To access the mouse as a regular user, create a udev rule:
+The installer and packages install `packaging/linux/99-venus-pro.rules`. For a
+source checkout, install that same reviewed file and reconnect the device:
 
 ```bash
-sudo tee /etc/udev/rules.d/99-venus-pro.rules >/dev/null <<'RULES'
-SUBSYSTEM=="usb", ATTR{idVendor}=="25a7", ATTR{idProduct}=="fa07", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTR{idVendor}=="25a7", ATTR{idProduct}=="fa08", MODE="0660", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTR{idVendor}=="04d9", ATTR{idProduct}=="fc55", MODE="0660", TAG+="uaccess"
-RULES
+sudo install -Dm644 packaging/linux/99-venus-pro.rules /etc/udev/rules.d/99-venus-pro.rules
 sudo udevadm control --reload-rules
-sudo udevadm trigger
+sudo udevadm trigger --subsystem-match=hidraw
 ```
 
-This is preferable to leaving the device world-writable.
+The rules cover both the `hidraw` node used by hidapi and the USB device node
+used by optional diagnostics. They use desktop-session ACLs (`TAG+="uaccess"`)
+with mode `0660`, rather than leaving the mouse world-writable.
+
+### “Mouse detected, but open failed”
+
+The Areson/Compx models expose multiple HID interfaces. Configuration is on
+interface 1; interface 0 is the boot mouse and cannot accept these feature
+reports. The app now selects the vendor interface explicitly. If it reports an
+access error after installation:
+
+1. Unplug and reconnect the mouse or wireless receiver.
+2. Confirm that `ls -l /dev/hidraw*` shows an ACL (`+`) for your desktop user.
+3. Close the Windows utility, Wine, virtual machines, and USB capture tools
+   that may have claimed the device, then click **Reconnect/Refresh**.
+
+For a read-only interface/access diagnostic (and optional battery query), run:
+
+```bash
+python3 tools/diagnose_device.py
+python3 tools/diagnose_device.py --battery
+```
+
+The wired `25a7:fa08`, wireless receiver `25a7:fa07`, and Holtek `04d9:fc55`
+variants use different interface selection where needed.
+
+### Battery tray compatibility
+
+The tray icon uses Qt `QSystemTrayIcon`, so it works with KDE Plasma, XFCE,
+MATE, and other desktops that expose a StatusNotifier/system tray. GNOME Shell
+normally requires its AppIndicator/KStatusNotifier extension. If the desktop
+does not expose a tray, the main configuration window still works normally.
+
+The RGB tab and tray menu both expose **Battery-color mouse LED**. This mode
+uses the lowest steady-light brightness found in the Windows capture, checks
+the battery once per minute, and writes a new color only when the hardware's
+10% battery step changes. Closing the window keeps it active in the tray;
+quitting the app restores the lighting that was active when the mode was
+enabled. The preference is remembered for the next launch.
+
+This is intentionally a user-session background controller rather than a root
+daemon: it shares the same hidraw/uaccess permissions as the GUI and can own a
+desktop tray icon. On desktops without a tray, the feature continues only
+while the main window remains open.
 
 ## Usage
 
@@ -152,6 +211,9 @@ Typical flow:
 Practical notes:
 
 - **Wired and wireless:** the app uses the wired connection when present and falls back to the wireless receiver when USB is disconnected.
+- **Battery:** command `0x04` reports 0–10 battery steps and whether the cable is connected; it is a status query, not a write commit.
+- **Battery LED:** enable it in the RGB tab or tray menu, then close the window
+  to leave the lightweight controller running in the desktop session.
 - **Factory reset:** the Advanced tab can restore defaults, but it also wipes custom macros.
 - **Read first:** when troubleshooting, start by reading the current device state before staging new writes.
 
@@ -159,7 +221,15 @@ Practical notes:
 
 - This project is based on reverse-engineered device behavior, so unsupported firmware or hardware variants may diverge.
 - The repo is focused on the Venus Pro family rather than generic MMO mouse support.
-- Some advanced macro or lighting behaviors may need protocol-level investigation before they can be expanded safely.
+- The `25a7:fa07/fa08` action table contains the 12 side buttons, fire, and the
+  three primary mouse buttons, but no entries for its physical top DPI buttons;
+  those appear firmware-fixed. The Holtek `04d9:fc55` map does expose DPI Up and
+  DPI Down, so those two buttons can be rebound on that variant.
+- Mouse movement is not accepted by the vendor macro converter. Native macro
+  clicks are supported; relative pointer movement is not currently offered.
+- The Areson lighting command is an EEPROM write rather than a known volatile
+  LED command. Battery LED mode therefore writes only on a reported 10% step
+  change and restores the prior lighting on normal application exit.
 
 ## Development
 
@@ -170,6 +240,21 @@ Useful repo entry points if you want to inspect or extend the protocol work:
 - `venus_protocol.py`: core protocol implementation
 - `staging_manager.py`: change staging system
 - `transaction_controller.py`: HID transaction handling
+
+Run the capture-backed, hardware-safe regression set explicitly:
+
+```bash
+python3 -m unittest \
+  tests.test_areson_protocol_offline tests.test_battery_led_gui \
+  tests.test_protocol tests.test_rgb tests.test_staging \
+  tests.test_atomic_controller tests.test_error_recovery
+```
+
+Do not treat unrestricted test discovery as hardware-safe. Several older
+files under `tests/` and `tools/` are preserved exploratory/replay programs;
+some write EEPROM, replay superseded packet guesses, or issue factory reset.
+The maintained utility, protocol module, decoder, diagnostic, and explicit
+offline suite above are the authoritative paths.
 
 ## Release checklist
 

--- a/com.github.es00bac.venusprolinux.appdata.xml
+++ b/com.github.es00bac.venusprolinux.appdata.xml
@@ -14,13 +14,16 @@
     <ul>
       <li>Full button remapping for all 16 buttons</li>
       <li>Macro recording and management</li>
+      <li>Native mouse-button events in hardware macros</li>
+      <li>Battery and cable status in the desktop tray</li>
+      <li>Minimum-brightness battery-color mouse LED mode</li>
       <li>RGB lighting configuration (Neon, Breathing, Steady)</li>
       <li>DPI profile settings (up to 16000 DPI)</li>
       <li>Polling rate adjustment (125Hz - 1000Hz)</li>
       <li>Profile management (save/load configurations)</li>
     </ul>
   </description>
-  <launchable type="desktop-id">com.github.es00bac.venusprolinux.desktop</launchable>
+  <launchable type="desktop-id">venusprolinux.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility/main/Buttons.png</image>
@@ -37,6 +40,9 @@
   </screenshots>
   <url type="homepage">https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility</url>
   <url type="bugtracker">https://github.com/Es00bac/UtechSmart-Venus-Pro-Linux-MMO-Mouse-Utility/issues</url>
-  <developer_name>Es00bac</developer_name>
+  <developer id="io.github.es00bac">
+    <name>Es00bac</name>
+  </developer>
+  <content_rating type="oars-1.1" />
   <update_contact>cabewse_at_gmail.com</update_contact>
 </component>

--- a/device_driver.py
+++ b/device_driver.py
@@ -26,7 +26,7 @@ def get_button_profiles(device_type: str) -> dict:
     return vp.BUTTON_PROFILES
 
 
-def create_device(device_type: str, path: str):
+def create_device(device_type: str, path: bytes | str):
     """Factory: create the right device class for the variant.
 
     Returns HoltekDevice or VenusDevice.

--- a/install.sh
+++ b/install.sh
@@ -18,30 +18,19 @@ sudo install -Dm644 icon.png /usr/share/icons/hicolor/512x512/apps/venusprolinux
 # Install desktop entry
 sudo install -Dm644 packaging/linux/venusprolinux.desktop /usr/share/applications/venusprolinux.desktop
 
-# Create launcher script
-cat << 'LAUNCHER' | sudo tee /usr/bin/venusprolinux > /dev/null
-#!/usr/bin/env python3
-import os
-import sys
-os.execv(sys.executable, [sys.executable, "/usr/share/venusprolinux/venus_gui.py"] + sys.argv[1:])
-LAUNCHER
+# Install the same launcher used by distribution packages.
+sudo install -Dm755 packaging/linux/venusprolinux /usr/bin/venusprolinux
 
-sudo chmod 755 /usr/bin/venusprolinux
+# Install metadata used by desktop software centers.
+sudo install -Dm644 com.github.es00bac.venusprolinux.appdata.xml \
+    /usr/share/metainfo/com.github.es00bac.venusprolinux.appdata.xml
 
 # Update icon cache
 sudo gtk-update-icon-cache -f /usr/share/icons/hicolor/ 2>/dev/null || true
 
-# Install udev rules for non-root access (hidraw for hidapi, usb for pyusb magic unlock)
-cat << 'UDEV' | sudo tee /etc/udev/rules.d/99-venus-pro.rules > /dev/null
-# Venus Pro (Wireless Receiver)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
-# Venus Pro (Wired)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
-# Venus MMO (Holtek variant)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
-UDEV
-sudo udevadm control --reload-rules && sudo udevadm trigger
+# Install the reviewed udev rules rather than maintaining a second copy here.
+sudo install -Dm644 packaging/linux/99-venus-pro.rules /etc/udev/rules.d/99-venus-pro.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger --subsystem-match=hidraw
 echo "udev rules installed to /etc/udev/rules.d/99-venus-pro.rules"
+echo "Unplug and reconnect the mouse/receiver so the new ACL is applied."

--- a/packaging/linux/99-venus-pro.rules
+++ b/packaging/linux/99-venus-pro.rules
@@ -1,14 +1,14 @@
 # UtechSmart Venus Pro / Venus MMO Gaming Mouse
-# Grants non-root access to hidraw (hidapi) and usb (pyusb) device nodes
+# Desktop sessions receive an ACL through uaccess; MODE is the safe fallback.
 
 # Venus Pro (Wireless Receiver)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa07", TAG+="uaccess", MODE="0660"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="25a7", ATTR{idProduct}=="fa07", TAG+="uaccess", MODE="0660"
 
 # Venus Pro (Wired)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="25a7", ATTRS{idProduct}=="fa08", TAG+="uaccess", MODE="0660"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="25a7", ATTR{idProduct}=="fa08", TAG+="uaccess", MODE="0660"
 
 # Venus MMO (Holtek variant)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d9", ATTRS{idProduct}=="fc55", TAG+="uaccess", MODE="0660"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="04d9", ATTR{idProduct}=="fc55", TAG+="uaccess", MODE="0660"

--- a/packaging/linux/venusprolinux
+++ b/packaging/linux/venusprolinux
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/python3 /usr/share/venusprolinux/venus_gui.py "$@"

--- a/packaging/linux/venusprolinux.desktop
+++ b/packaging/linux/venusprolinux.desktop
@@ -8,3 +8,4 @@ Type=Application
 Categories=Settings;HardwareSettings;
 Keywords=mouse;configuration;macro;rgb;
 StartupNotify=true
+StartupWMClass=venusprolinux

--- a/tests/test_areson_protocol_offline.py
+++ b/tests/test_areson_protocol_offline.py
@@ -1,0 +1,218 @@
+"""Offline regression tests backed by captures and the vendor converter."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import venus_protocol as vp
+
+
+def response_for(request: bytes, data: bytes = b"") -> bytes:
+    response = bytearray(request)
+    response[0] = vp.RESPONSE_REPORT_ID
+    if data:
+        response[5] = len(data)
+        response[6:16] = data.ljust(10, b"\x00")
+    response[16] = vp.calc_checksum(response[:16])
+    return bytes(response)
+
+
+class FakeHandle:
+    def __init__(self):
+        self.pending = []
+        self.commands = []
+        self.status_data = b"\x07\x00"
+
+    def set_nonblocking(self, value):
+        pass
+
+    def send_feature_report(self, request):
+        request = bytes(request)
+        self.commands.append(request[1])
+        command = request[1]
+        if command == vp.CMD_READY:
+            data = b"\x01"
+        elif command == vp.CMD_CHALLENGE:
+            data = vp.challenge_response(request[6:10])
+        elif command == vp.CMD_NOTIFY:
+            data = b"\x01"
+        elif command == vp.CMD_STATUS:
+            data = self.status_data
+        elif command == vp.CMD_READ:
+            data = bytes(request[5])
+        else:
+            data = b""
+        self.pending.append(response_for(request, data))
+        return len(request)
+
+    def read(self, length, timeout_ms=0):
+        return list(self.pending.pop(0)) if self.pending else []
+
+    def close(self):
+        pass
+
+
+class ProtocolBuilderTests(unittest.TestCase):
+    def test_packet_checksum_invariant(self):
+        packets = [
+            vp.build_simple(vp.CMD_READY),
+            vp.build_memory_write(0x0060, b"\x01\x01\x00\x53"),
+            vp.build_flash_read(0x12, 0x34, 10),
+        ]
+        self.assertTrue(all(len(packet) == 17 for packet in packets))
+        self.assertTrue(all(vp.report_checksum_valid(packet) for packet in packets))
+        with self.assertRaises(ValueError):
+            vp.build_report(vp.CMD_READY, bytes(15))
+
+    def test_challenge_formula_matches_independent_captures(self):
+        pairs = {
+            "15251e09": "3f686339",
+            "56573d1b": "b2ebd2c2",
+            "57605d4d": "bc1d648b",
+            "211f3553": "4573f26d",
+            "64282615": "917687b8",
+        }
+        for challenge, expected in pairs.items():
+            self.assertEqual(vp.challenge_response(bytes.fromhex(challenge)).hex(), expected)
+
+    def test_mouse_action_records_match_capture(self):
+        expected = {
+            0x01: "01010053",
+            0x02: "01020052",
+            0x04: "01040050",
+            0x08: "0108004c",
+            0x10: "01100044",
+        }
+        for mask, record in expected.items():
+            packet = vp.build_mouse_param(0x60, mask)
+            self.assertEqual(packet[6:10].hex(), record)
+
+    def test_multi_modifier_definition_matches_capture(self):
+        packets = vp.build_key_binding(
+            0x01, 0x00, 0x1E, vp.MODIFIER_CTRL | vp.MODIFIER_SHIFT)
+        body = b"".join(packet[6:6 + packet[5]] for packet in packets)
+        self.assertEqual(
+            body.hex(),
+            "06800100800200811e00400100400200411e00cb",
+        )
+        self.assertEqual(sum(body) & 0xFF, 0x55)
+
+    def test_consumer_definition_is_16_bit(self):
+        packets = vp.build_consumer_binding(1, 0, 0x0183)
+        body = b"".join(packet[6:6 + packet[5]] for packet in packets)
+        self.assertEqual(body[:7], bytes.fromhex("02828301428301"))
+        self.assertEqual(sum(body) & 0xFF, 0x55)
+
+    def test_polling_codes(self):
+        self.assertEqual(vp.POLLING_RATE_CODES,
+                         {125: 0x08, 250: 0x04, 500: 0x02, 1000: 0x01})
+        for rate, code in vp.POLLING_RATE_CODES.items():
+            self.assertEqual(vp.POLLING_RATE_PAYLOADS[rate][4:6],
+                             bytes((code, (0x55 - code) & 0xFF)))
+
+    def test_battery_led_gradient_uses_captured_minimum_brightness(self):
+        self.assertEqual(vp.battery_gradient_rgb(0), (255, 0, 0))
+        self.assertEqual(vp.battery_gradient_rgb(25), (255, 128, 0))
+        self.assertEqual(vp.battery_gradient_rgb(50), (255, 255, 0))
+        self.assertEqual(vp.battery_gradient_rgb(75), (128, 255, 0))
+        self.assertEqual(vp.battery_gradient_rgb(100), (0, 255, 0))
+
+        packet = vp.build_battery_indicator_rgb(60)
+        self.assertEqual(packet[6:9], bytes((204, 255, 0)))
+        self.assertEqual(packet[10], vp.RGB_MODE_STEADY)
+        self.assertEqual(packet[12:14], b"\x01\x54")
+        self.assertTrue(vp.report_checksum_valid(packet))
+        self.assertEqual(
+            vp.build_battery_indicator_rgb(0)[6:14],
+            bytes.fromhex("ff00005601540154"),
+        )
+
+    def test_macro_mouse_events_and_checksum(self):
+        down = vp.MacroEvent.mouse(0x01, True, 50)
+        up = vp.MacroEvent.mouse(0x01, False, 3)
+        self.assertEqual(down.to_bytes(), bytes.fromhex("8401000032"))
+        self.assertEqual(up.to_bytes(), bytes.fromhex("4401000003"))
+        events = down.to_bytes() + up.to_bytes()
+        header = bytes(31) + b"\x02"
+        checksum = vp.calculate_terminator_checksum(header + events, 2)
+        self.assertEqual((2 + sum(events) + checksum) & 0xFF, 0x55)
+
+    def test_macro_slot_addresses_use_0x180_stride(self):
+        self.assertEqual(vp.get_macro_slot_info(0), (0x03, 0x00))
+        self.assertEqual(vp.get_macro_slot_info(1), (0x04, 0x80))
+        self.assertEqual(vp.get_macro_slot_info(2), (0x06, 0x00))
+        self.assertEqual(vp.get_macro_slot_info(15), (0x19, 0x80))
+        with self.assertRaises(ValueError):
+            vp.get_macro_slot_info(16)
+
+    def test_maximum_macro_image_stays_inside_its_slot(self):
+        events = [vp.MacroEvent(0x04, True, 3)] * vp.MACRO_MAX_EVENTS
+        image = vp.build_macro_image("A\U0001f600B", events)
+        self.assertEqual(len(image), 381)
+        self.assertLessEqual(len(image), vp.MACRO_SLOT_SIZE)
+        # The astral character occupies two UTF-16 code units, but the stored
+        # name length must still describe exactly the bytes in the header.
+        self.assertEqual(image[0], 8)
+        self.assertEqual(image[0x1F], 69)
+        terminator_offset = vp.MACRO_HEADER_SIZE + len(events) * 5
+        self.assertEqual(
+            image[terminator_offset],
+            vp.calculate_terminator_checksum(image, len(events)),
+        )
+        with self.assertRaisesRegex(ValueError, "at most 69"):
+            vp.build_macro_image("too many", events + events[:1])
+
+
+class DeviceTests(unittest.TestCase):
+    def test_status_and_safe_unlock_alias(self):
+        handle = FakeHandle()
+        device = vp.VenusDevice(b"/dev/fake")
+        device._dev = handle
+        status = device.query_status()
+        self.assertEqual((status.level, status.percent, status.cable_connected),
+                         (7, 70, False))
+        self.assertTrue(device.unlock())
+        self.assertNotIn(vp.CMD_FACTORY_RESET, handle.commands)
+
+    def test_status_rejects_out_of_range_battery_steps(self):
+        handle = FakeHandle()
+        handle.status_data = b"\xff\x00"
+        device = vp.VenusDevice(b"/dev/fake")
+        device._dev = handle
+        with self.assertRaisesRegex(vp.ProtocolError, "battery step"):
+            device.query_status()
+
+    def test_enumeration_selects_real_config_interface(self):
+        entries = [
+            {"vendor_id": 0x25A7, "product_id": 0xFA08,
+             "path": b"/dev/hidraw-mouse", "interface_number": 0,
+             "product_string": "Venus Pro"},
+            {"vendor_id": 0x25A7, "product_id": 0xFA08,
+             "path": b"/dev/hidraw-config", "interface_number": 1,
+             "usage_page": 0x0001, "usage": 0x0006,
+             "product_string": "Venus Pro"},
+            # hidapi enumerates every top-level collection separately, often
+            # with the same hidraw path. Prefer the actual vendor collection.
+            {"vendor_id": 0x25A7, "product_id": 0xFA08,
+             "path": b"/dev/hidraw-config", "interface_number": 1,
+             "usage_page": 0xFF02, "product_string": "Venus Pro"},
+        ]
+
+        fake_hid = mock.Mock()
+        fake_hid.enumerate.side_effect = lambda vid, pid: (
+            entries if (vid, pid) == (0x25A7, 0xFA08) else [])
+        fake_handle = mock.Mock()
+        fake_hid.device.return_value = fake_handle
+        with mock.patch.object(vp, "hid", fake_hid), \
+             mock.patch.object(vp, "HIDAPI_AVAILABLE", True):
+            devices = vp.list_devices()
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].path, b"/dev/hidraw-config")
+        self.assertEqual(devices[0].usage_page, 0xFF02)
+        fake_handle.open_path.assert_called_with(b"/dev/hidraw-config")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_battery_led_gui.py
+++ b/tests/test_battery_led_gui.py
@@ -1,0 +1,111 @@
+"""Headless lifecycle checks for the battery-colour LED controller."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt6 import QtWidgets
+
+    import venus_gui as gui
+    import venus_protocol as vp
+except ImportError:  # pragma: no cover - exercised on minimal test hosts
+    QtWidgets = None
+    gui = None
+    vp = None
+
+
+@unittest.skipIf(QtWidgets is None, "PyQt6 is not installed")
+class BatteryLedControllerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    def setUp(self):
+        self.temp_home = TemporaryDirectory()
+        self.home_patch = mock.patch.object(
+            gui.Path, "home", return_value=Path(self.temp_home.name))
+        self.device_patch = mock.patch.object(gui.vp, "list_devices", return_value=[])
+        self.tray_patch = mock.patch.object(
+            gui.QtWidgets.QSystemTrayIcon,
+            "isSystemTrayAvailable",
+            return_value=False,
+        )
+        self.home_patch.start()
+        self.device_patch.start()
+        self.tray_patch.start()
+        self.window = gui.MainWindow()
+        self.window.device_type = "venus_pro"
+        self.window.device_path = b"/dev/fake"
+        self.window._request_battery_refresh = mock.Mock()
+
+    def tearDown(self):
+        self.window.battery_timer.stop()
+        self.window.close()
+        self.window.deleteLater()
+        self.tray_patch.stop()
+        self.device_patch.stop()
+        self.home_patch.stop()
+        self.temp_home.cleanup()
+
+    def test_toggle_updates_once_per_step_then_restores_manual_lighting(self):
+        manual = self.window._capture_rgb_restore()
+        self.window._set_battery_led_enabled(True)
+
+        self.assertTrue(self.window.battery_led_enabled)
+        self.assertEqual(self.window._battery_led_restore, manual)
+        self.window._request_battery_refresh.assert_called_once_with()
+
+        send = mock.Mock(return_value=True)
+        self.window._send_reports = send
+        status = vp.BatteryStatus(6, 60, False, b"\x06\x00")
+        self.window._apply_battery_led_status(status)
+        self.window._apply_battery_led_status(status)
+
+        send.assert_called_once()
+        indicator_reports = send.call_args.args[0]
+        self.assertEqual(
+            indicator_reports[1], vp.build_battery_indicator_rgb(60))
+
+        self.window._set_battery_led_enabled(False)
+        self.assertFalse(self.window.battery_led_enabled)
+        self.assertEqual(send.call_count, 2)
+        restore_reports = send.call_args.args[0]
+        self.assertEqual(
+            restore_reports[1],
+            vp.build_rgb(
+                manual["r"], manual["g"], manual["b"],
+                manual["mode"], manual["brightness"],
+            ),
+        )
+
+        saved = json.loads(self.window.settings_file.read_text(encoding="utf-8"))
+        self.assertFalse(saved["battery_led_enabled"])
+
+    def test_automatic_connect_requests_a_silent_read(self):
+        info = vp.DeviceInfo(
+            path=b"/dev/fake",
+            product="Test receiver",
+            manufacturer="Test",
+            vendor_id=0x25A7,
+            product_id=0xFA07,
+            serial="",
+            interface_number=1,
+            usage_page=0xFF02,
+            usage=2,
+        )
+        self.window._read_settings = mock.Mock()
+        with mock.patch.object(gui.vp, "list_devices", return_value=[info]):
+            self.window._refresh_and_connect(silent=True)
+        self.window._read_settings.assert_called_once_with(silent=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -12,7 +12,7 @@ import venus_protocol as vp
 
 class TestProtocol(unittest.TestCase):
     def test_packet_checksum(self):
-        # Cmd 04 (Prepare)
+        # Cmd 04 (battery/status)
         # 08 04 ... (total 16 bytes)
         # Sum = 0x0C (8+4)
         # Checksum = 0x55 - 0x0C = 0x49
@@ -32,8 +32,8 @@ class TestProtocol(unittest.TestCase):
         pkt = vp.build_macro_bind(0x60, 0, 1)
         # Payload starts at pkt[6] (D0=Len, D1=Type, D2=Slot, D3=Mode, D4=Chk)
         # Wait, check build_flash_write: payload = [0x00, page, offset, len, data...]
-        # data = [btype, index, repeat, chk, ...]
-        # pkt[0]=0x08, pkt[1]=0x07, pkt[2]=0x00, pkt[3]=0x00, pkt[4]=0x60, pkt[5]=0x08
+        # data = [btype, index, repeat, chk]
+        # pkt[0]=0x08, pkt[1]=0x07, pkt[2]=0x00, pkt[3]=0x00, pkt[4]=0x60, pkt[5]=0x04
         # pkt[6]=0x06, pkt[7]=0x00, pkt[8]=0x01, pkt[9]=0x4E
         self.assertEqual(pkt[9], 0x4E)
 

--- a/tests/test_rgb.py
+++ b/tests/test_rgb.py
@@ -38,5 +38,9 @@ class TestRGB(unittest.TestCase):
         pkt = vp.build_rgb(0xE4, 0x00, 0x7F, vp.RGB_MODE_STEADY, 100)
         self.assertEqual(pkt[9], 0xF2)
 
+    def test_build_rgb_neon_uses_mode_complement(self):
+        pkt = vp.build_rgb(0xFF, 0x00, 0xFF, vp.RGB_MODE_NEON, 20)
+        self.assertEqual(pkt[10:14], bytes.fromhex("02533c19"))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/GhidraDecompileRange.java
+++ b/tools/GhidraDecompileRange.java
@@ -1,0 +1,55 @@
+// Decompile every function whose entry point falls in one or more address ranges.
+// Arguments: output.txt start1 end1 [start2 end2 ...]
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionIterator;
+
+public class GhidraDecompileRange extends GhidraScript {
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 3 || args.length % 2 == 0) {
+            throw new IllegalArgumentException("expected output plus start/end address pairs");
+        }
+
+        DecompInterface decompiler = new DecompInterface();
+        decompiler.openProgram(currentProgram);
+        try (PrintWriter out = new PrintWriter(new File(args[0]))) {
+            FunctionIterator iterator = currentProgram.getFunctionManager().getFunctions(true);
+            while (iterator.hasNext()) {
+                Function function = iterator.next();
+                Address entry = function.getEntryPoint();
+                boolean selected = false;
+                for (int i = 1; i < args.length; i += 2) {
+                    Address start = currentProgram.getAddressFactory().getAddress(args[i]);
+                    Address end = currentProgram.getAddressFactory().getAddress(args[i + 1]);
+                    if (entry.compareTo(start) >= 0 && entry.compareTo(end) <= 0) {
+                        selected = true;
+                        break;
+                    }
+                }
+                if (!selected || monitor.isCancelled()) {
+                    continue;
+                }
+
+                out.printf("===== %s @ %s =====%n%n", function.getName(), entry);
+                DecompileResults result = decompiler.decompileFunction(function, 90, monitor);
+                if (result.decompileCompleted() && result.getDecompiledFunction() != null) {
+                    out.println(result.getDecompiledFunction().getC());
+                } else {
+                    out.println("DECOMPILE FAILED: " + result.getErrorMessage());
+                }
+                out.println();
+            }
+        } finally {
+            decompiler.dispose();
+        }
+    }
+}

--- a/tools/GhidraDumpMemory.java
+++ b/tools/GhidraDumpMemory.java
@@ -1,0 +1,34 @@
+// Dump initialized memory as hex. Arguments: output.txt address length
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.Address;
+
+public class GhidraDumpMemory extends GhidraScript {
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length != 3) {
+            throw new IllegalArgumentException("expected output, address, and byte length");
+        }
+        Address address = currentProgram.getAddressFactory().getAddress(args[1]);
+        int length = Integer.decode(args[2]);
+        byte[] data = new byte[length];
+        currentProgram.getMemory().getBytes(address, data);
+        try (PrintWriter out = new PrintWriter(new File(args[0]))) {
+            for (int offset = 0; offset < data.length; offset += 16) {
+                out.printf("%s  ", address.add(offset));
+                int end = Math.min(offset + 16, data.length);
+                for (int i = offset; i < end; i++) {
+                    out.printf("%02x", data[i] & 0xff);
+                    if (i + 1 < end) {
+                        out.print(" ");
+                    }
+                }
+                out.println();
+            }
+        }
+    }
+}

--- a/tools/GhidraProtocolExport.java
+++ b/tools/GhidraProtocolExport.java
@@ -1,0 +1,86 @@
+// Export decompiled functions that reference protocol-related strings.
+// Run with analyzeHeadless ... -postScript GhidraProtocolExport.java output.txt
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
+
+public class GhidraProtocolExport extends GhidraScript {
+    private static final String[] NEEDLES = {
+        "macrohasmskey", "stmacro_to_hdmacro", "hdmacro_to_stmacro",
+        "writeeeprom", "readeeprom", "waitnotify", "cread:",
+        "bcddevice", "start apply", "markled", "hgetprofile",
+        "getprofile", "getmacroname", "setfeature", "challenge"
+    };
+
+    private boolean interesting(String value) {
+        String lower = value.toLowerCase(Locale.ROOT);
+        for (String needle : NEEDLES) {
+            if (lower.contains(needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length != 1) {
+            throw new IllegalArgumentException("expected one output-file argument");
+        }
+
+        Set<Function> functions = new LinkedHashSet<>();
+        try (PrintWriter out = new PrintWriter(new File(args[0]))) {
+            out.println("PROGRAM " + currentProgram.getName());
+            out.println();
+
+            for (Data data : currentProgram.getListing().getDefinedData(true)) {
+                Object value = data.getValue();
+                if (!(value instanceof String) || !interesting((String) value)) {
+                    continue;
+                }
+                out.printf("STRING %s %s%n", data.getAddress(), value);
+                ReferenceIterator refs = currentProgram.getReferenceManager()
+                    .getReferencesTo(data.getAddress());
+                while (refs.hasNext()) {
+                    Reference ref = refs.next();
+                    Function function = currentProgram.getFunctionManager()
+                        .getFunctionContaining(ref.getFromAddress());
+                    out.printf("  XREF %s%s%n", ref.getFromAddress(),
+                        function == null ? "" : " in " + function.getName() + "@" + function.getEntryPoint());
+                    if (function != null) {
+                        functions.add(function);
+                    }
+                }
+            }
+
+            DecompInterface decompiler = new DecompInterface();
+            decompiler.openProgram(currentProgram);
+            for (Function function : functions) {
+                if (monitor.isCancelled()) {
+                    break;
+                }
+                out.println();
+                out.printf("===== %s @ %s =====%n", function.getName(), function.getEntryPoint());
+                DecompileResults result = decompiler.decompileFunction(function, 90, monitor);
+                if (result.decompileCompleted() && result.getDecompiledFunction() != null) {
+                    out.println(result.getDecompiledFunction().getC());
+                } else {
+                    out.println("DECOMPILE FAILED: " + result.getErrorMessage());
+                }
+            }
+            decompiler.dispose();
+        }
+    }
+}

--- a/tools/decode_areson_pcap.py
+++ b/tools/decode_areson_pcap.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Decode Areson Venus feature requests and interrupt responses from USBPcap."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+COMMANDS = {
+    0x01: "challenge",
+    0x02: "notify/driver-state",
+    0x03: "ready",
+    0x04: "battery/status",
+    0x07: "EEPROM write",
+    0x08: "EEPROM read",
+    0x09: "FACTORY RESET",
+}
+
+
+def region(address: int) -> str:
+    if address == 0:
+        return "polling"
+    if 0x000C <= address <= 0x002B:
+        return f"DPI slot {(address - 0x000C) // 4}"
+    if 0x002C <= address <= 0x005F:
+        return "lighting/DPI-color"
+    if 0x0060 <= address <= 0x009F:
+        return f"button action {(address - 0x0060) // 4}"
+    if 0x0100 <= address <= 0x02FF:
+        return f"event definition {(address - 0x0100) // 0x20}"
+    if 0x0300 <= address <= 0x1AFF:
+        slot = (address - 0x0300) // 0x180
+        offset = (address - 0x0300) % 0x180
+        return f"macro {slot} +0x{offset:03x}"
+    return "unknown region"
+
+
+def describe(packet: bytes) -> str:
+    direction = "REQ" if packet[0] == 0x08 else "RSP"
+    command = packet[1]
+    name = COMMANDS.get(command, "unknown")
+    length = packet[5]
+    data = packet[6:6 + min(length, 10)]
+    valid = "ok" if sum(packet) & 0xFF == 0x55 else "BAD-CHECKSUM"
+    prefix = f"{direction} cmd={command:02x} {name} checksum={valid}"
+
+    if command in (0x07, 0x08):
+        address = int.from_bytes(packet[3:5], "big")
+        return (f"{prefix} addr={address:04x} len={length} "
+                f"data={data.hex() or '-'} [{region(address)}]")
+    if command == 0x04 and direction == "RSP" and length >= 2:
+        battery = (f"{data[0] * 10}%" if data[0] <= 10
+                   else f"invalid-step-{data[0]}")
+        return (f"{prefix} battery={battery} "
+                f"cable={bool(data[1])} raw={data[:2].hex()}")
+    if command == 0x01 and length == 4:
+        return f"{prefix} value={data.hex()}"
+    if length:
+        return f"{prefix} len={length} data={data.hex()}"
+    return prefix
+
+
+def extract(path: Path):
+    if shutil.which("tshark") is None:
+        raise RuntimeError("tshark is required (install Wireshark CLI tools)")
+    command = [
+        "tshark", "-r", str(path),
+        "-Y", "usb.data_fragment || usbhid.data",
+        "-T", "fields", "-E", "separator=|", "-E", "occurrence=f",
+        "-e", "frame.number", "-e", "frame.time_relative",
+        "-e", "usb.endpoint_address", "-e", "usb.data_fragment",
+        "-e", "usbhid.data",
+    ]
+    result = subprocess.run(command, check=True, text=True, capture_output=True)
+    for line in result.stdout.splitlines():
+        columns = line.split("|")
+        if len(columns) != 5:
+            continue
+        frame, timestamp, endpoint, control_data, interrupt_data = columns
+        value = control_data or interrupt_data
+        try:
+            packet = bytes.fromhex(value.replace(":", ""))
+        except ValueError:
+            continue
+        if len(packet) == 17 and packet[0] in (0x08, 0x09):
+            yield frame, timestamp, endpoint, packet
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", type=Path)
+    parser.add_argument("--hex", action="store_true", help="append the raw report")
+    args = parser.parse_args()
+    if not args.capture.is_file():
+        parser.error(f"capture does not exist: {args.capture}")
+
+    try:
+        for frame, timestamp, endpoint, packet in extract(args.capture):
+            raw = f" raw={packet.hex()}" if args.hex else ""
+            print(f"{int(frame):6d} {float(timestamp):10.6f} ep={endpoint or 'ctrl':>4} "
+                  f"{describe(packet)}{raw}")
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnose_device.py
+++ b/tools/diagnose_device.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""List supported Venus configuration interfaces and optionally read battery status."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+for parent in Path(__file__).resolve().parents:
+    if (parent / "venus_protocol.py").is_file():
+        sys.path.insert(0, str(parent))
+        break
+
+import venus_protocol as vp
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--battery",
+        action="store_true",
+        help="send the read-only Areson status command (0x04)",
+    )
+    args = parser.parse_args()
+
+    if not vp.HIDAPI_AVAILABLE:
+        print("python-hidapi is not installed", file=sys.stderr)
+        return 2
+
+    devices = vp.list_devices()
+    if not devices:
+        print("No supported vendor configuration interface found.")
+        return 1
+
+    failed = False
+    for info in devices:
+        print(
+            f"{info.vendor_id:04x}:{info.product_id:04x} "
+            f"interface={info.interface_number} usage={info.usage_page:04x}:{info.usage:04x} "
+            f"path={info.display_path} product={info.product!r}"
+        )
+        if info.access_error:
+            print(f"  access: {info.access_error}")
+            failed = True
+            continue
+        print("  access: OK")
+
+        if args.battery and info.vendor_id == 0x25A7:
+            device = vp.VenusDevice(info.path)
+            try:
+                device.open()
+                status = device.query_status()
+                connection = "USB cable" if status.cable_connected else "wireless"
+                print(
+                    f"  battery: {status.percent}% ({connection}, raw={status.raw.hex()})"
+                )
+            except Exception as exc:
+                print(f"  battery read failed: {exc}")
+                failed = True
+            finally:
+                device.close()
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dump_memory.py
+++ b/tools/dump_memory.py
@@ -1,15 +1,14 @@
 from pathlib import Path
+import os
 import sys
+import time
 
 for _parent in Path(__file__).resolve().parents:
     if (_parent / "venus_protocol.py").exists():
         sys.path.insert(0, str(_parent))
         break
 
-import sys
-import os
-import time
-from venus_protocol import VenusDevice, VENDOR_ID, PRODUCT_IDS, list_devices
+from venus_protocol import VenusDevice, list_devices
 
 def main():
     avail = list_devices()

--- a/transaction_controller.py
+++ b/transaction_controller.py
@@ -1,8 +1,9 @@
 class TransactionController:
-    """
-    Orchestrates the application of staged changes to the device.
-    Ensures atomicity by attempting to send all packets and only committing
-    the stage if successful.
+    """Send staged changes sequentially and update local state on success.
+
+    Areson EEPROM writes persist as soon as each packet is acknowledged, so
+    this is deliberately not described as an atomic transaction: a failure can
+    leave the successfully written prefix on the device.
     """
     def __init__(self, device, packet_builder, logger=None):
         """
@@ -46,9 +47,8 @@ class TransactionController:
 
         self._log(f"TransactionController: Built {len(all_packets)} packets. Sending...")
 
-        # 2. Send packets
-        # In a real atomic setup, we might want to verify state, but 
-        # for HID, reliable send is our best proxy.
+        # 2. Send packets. Each successful ACK may already represent a
+        # persistent EEPROM change.
         for i, pkt in enumerate(all_packets):
             if not self.device.send_reliable(pkt):
                 self._log(f"TransactionController: Send failed at packet {i}/{len(all_packets)} ({pkt.hex()})")
@@ -58,7 +58,7 @@ class TransactionController:
             if i % 5 == 0:
                 self._log(f"TransactionController: Sent packet {i+1}/{len(all_packets)}")
 
-        # 3. Commit state on success
-        self._log("TransactionController: All packets sent. Committing state.")
+        # 3. Update the application's base state only after all ACKs.
+        self._log("TransactionController: All packets acknowledged; updating local state.")
         staging_manager.commit()
         return True

--- a/venus_gui.py
+++ b/venus_gui.py
@@ -8,27 +8,11 @@ from copy import deepcopy
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-try:
-    import evdev
-    from evdev import UInput, ecodes as e
-    EVDEV_AVAILABLE = True
-except ImportError:
-    EVDEV_AVAILABLE = False
-
 import venus_protocol as vp
 import holtek_protocol as hp
 import device_driver as dd
 from staging_manager import StagingManager
 from transaction_controller import TransactionController
-
-
-KEY_USAGE = {chr(ord("A") + i): 0x04 + i for i in range(26)}
-
-DEFAULT_MACRO_EVENTS_HEX = (
-    "000e811700005d411700009d810800005d41080000bc811600006d411600009c811700005e41170000"
-    "9c810c00005e410c0000bc811100004e41110000cb810a00005e410a00"
-)
-DEFAULT_MACRO_TAIL_HEX = "000369000000"
 
 
 class KeyCaptureEdit(QtWidgets.QLineEdit):
@@ -147,130 +131,36 @@ class KeyCaptureEdit(QtWidgets.QLineEdit):
             self.keyChanged.emit()
 
 
-class MacroRunner(QtCore.QThread):
-    """
-    Background service that listens for specific trigger keys (F13-F24)
-    from the Venus Mouse and executes associated software macros.
-    """
-    log_signal = QtCore.pyqtSignal(str)
+class BatteryQueryThread(QtCore.QThread):
+    """Run the short status exchange without blocking the Qt event loop."""
 
-    def __init__(self, parent=None):
+    completed = QtCore.pyqtSignal(object, str)
+
+    def __init__(self, path: bytes | str, parent=None):
         super().__init__(parent)
-        self.running = False
-        self.macros = {} # Key Code (int) -> List of Events
-        self.uinput = None
-        self.phys_dev = None
+        self.path = path
 
-    def load_macros(self, macro_map):
-        """
-        macro_map: dict of {TriggerKeyName: MacroEventList}
-        Example: {"F13": [...], "F14": [...]}
-        """
-        self.macros = {}
-        if not EVDEV_AVAILABLE:
-            return
-
-        for key_name, events in macro_map.items():
-            # Resolve key name to Linux Key Code
-            # F13 -> KEY_F13 (183)
-            # We use evdev.ecodes
+    def run(self) -> None:
+        device = vp.VenusDevice(self.path)
+        status = None
+        error = ""
+        try:
+            device.open()
+            status = device.query_status()
+        except Exception as exc:
+            error = str(exc)
+        finally:
             try:
-                # evdev keys are like 'KEY_F13'
-                ecode_name = f"KEY_{key_name.upper()}"
-                code = getattr(e, ecode_name, None)
-                if code:
-                    self.macros[code] = events
+                device.close()
             except Exception:
                 pass
-
-    def run(self):
-        if not EVDEV_AVAILABLE:
-            self.log_signal.emit("MacroRunner: evdev not found. Software macros disabled.")
-            return
-
-        self.running = True
-        
-        # 1. Find Device (UtechSmart)
-        self.log_signal.emit("MacroRunner: Scanning for device...")
-        target_path = None
-        
-        # Simple scan
-        try:
-            devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
-            for dev in devices:
-                if "Venus" in dev.name or "2.4G" in dev.name:
-                    # Check if it has keys?
-                    caps = dev.capabilities()
-                    if e.EV_KEY in caps:
-                        self.log_signal.emit(f"MacroRunner: Found {dev.name} at {dev.path}")
-                        target_path = dev.path
-                        break
-        except Exception as exc:
-            self.log_signal.emit(f"MacroRunner: Scan error {exc}")
-            return
-
-        if not target_path:
-            self.log_signal.emit("MacroRunner: Mouse input device not found.")
-            return
-
-        # 2. Setup UInput (Virtual Keyboard for playback)
-        try:
-            self.phys_dev = evdev.InputDevice(target_path)
-            # Create uinput device with ALL keys capability
-            cap = {
-                e.EV_KEY: list(range(0, 500)), # Enable all keys
-                e.EV_REL: [e.REL_X, e.REL_Y, e.REL_WHEEL],
-                e.EV_ABS: []
-            }
-            self.uinput = UInput(cap, name="Venus Macro Injector")
-            self.log_signal.emit("MacroRunner: Virtual Injector Created.")
-        except Exception as exc:
-             self.log_signal.emit(f"MacroRunner: Setup error {exc}")
-             return
-
-        # 3. Loop
-        self.log_signal.emit("MacroRunner: Listening for Triggers...")
-        try:
-            # Exclusive grab? No, passive listen.
-            for event in self.phys_dev.read_loop():
-                if not self.running:
-                    break
-                
-                if event.type == e.EV_KEY and event.value == 1: # Key Down
-                    if event.code in self.macros:
-                        self.log_signal.emit(f"MacroRunner: Trigger {event.code} detected!")
-                        self.play_macro(self.macros[event.code])
-                        
-        except Exception as exc:
-            self.log_signal.emit(f"MacroRunner: Loop error {exc}")
-        finally:
-            if self.uinput:
-                self.uinput.close()
-
-    def play_macro(self, events):
-        """
-        Replay events using uinput.
-        Events is a list of dicts/objects from the GUI editor.
-        Protocol events are: [Type, Code, Value?]
-        We need to map internal GUI format to Linux Keys.
-        GUI format: (Type=Mouse/Key, Code=HID_USAGE, Value=Down/Up)
-        We need HID_USAGE -> LINUX_KEY_CODE mapping.
-        """
-        # Mapping HID to Linux is painful.
-        # HID 0x04 (A) -> KEY_A (30)
-        # We can implement a small mapper or use evdev's ecodes if names match?
-        # Protocol keys: vp.HID_KEY_USAGE["A"] = 0x04
-        # We'll need a lookup.
-        pass # To be implemented in detail
-    
-    def stop(self):
-        self.running = False
+        self.completed.emit(status, error)
 
 
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle("Venus Pro Config v0.2.1 (Reverse Engineering)")
+        self.setWindowTitle("Venus Pro Config")
         self.resize(1200, 780)
         
         # Set Application Icon
@@ -284,20 +174,31 @@ class MainWindow(QtWidgets.QMainWindow):
             app.setDesktopFileName("venusprolinux")
 
         # Store device path instead of keeping device open (prevents blocking mouse input)
-        self.device_path: str | None = None
+        self.device_path: bytes | str | None = None
         self.device_infos: list[vp.DeviceInfo] = []
         self.device_type: str = 'venus_pro'  # 'venus_pro' or 'holtek'
         self.holtek_profile: int = 0  # 0-4, selected hardware profile for Holtek device
         self.active_button_profiles: dict = vp.BUTTON_PROFILES
         self.custom_profiles: dict[str, tuple[int, int, int]] = {}
         self.button_assignments: dict[str, dict] = {} # Stored button settings from device
+        self._battery_thread: BatteryQueryThread | None = None
+        self._quitting = False
+        self._tray_notice_shown = False
+        self._shutdown_restore_done = False
+        self._last_battery_led_level: int | None = None
+        self._last_battery_status: tuple[int, bool] | None = None
+        self._battery_led_restore: dict[str, int] | None = None
+        self.battery_led_enabled = False
+        self._config_errors: list[str] = []
         
         # Load macro names from config EARLY (before UI build)
         self.config_dir = Path.home() / ".config" / "venus_pro_linux"
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.macro_config_file = self.config_dir / "macros.json"
+        self.settings_file = self.config_dir / "settings.json"
         self.macro_names: dict[int, str] = {}
         self._load_macro_names()
+        self._load_app_settings()
 
 
         root = QtWidgets.QWidget()
@@ -330,26 +231,26 @@ class MainWindow(QtWidgets.QMainWindow):
         # Let's instantiate controller on demand in _commit_changes for now.
         
         self._initialize_default_assignments()
+        self._setup_tray()
 
-        # Attempt to unlock device (requires root, but try anyway)
-        # This will freeze mouse momentarily
-        # if vp.PYUSB_AVAILABLE:
-        #     self._log("Init: Attempting Startup Unlock (PyUSB)...")
-        #     try:
-        #         vp.unlock_device()
-        #         self._log("Init: Unlock command sent.")
-        #     except Exception as e:
-        #         self._log(f"Init: Unlock failed: {e}")
+        for message in self._config_errors:
+            self._log(message)
+        self._config_errors.clear()
 
         self._log("Init: Refreshing and connecting...")
         
-        self._refresh_and_connect()
+        # The initial read runs before main() shows this window.  It must not
+        # create a modal message box, otherwise opening the parent from the
+        # tray exposes a completely disabled-looking interface.
+        self._refresh_and_connect(silent=True)
         
         # Keyboard shortcuts for Undo/Redo
         undo_shortcut = QtGui.QShortcut(QtGui.QKeySequence.StandardKey.Undo, self)
         undo_shortcut.activated.connect(self._on_undo)
         redo_shortcut = QtGui.QShortcut(QtGui.QKeySequence.StandardKey.Redo, self)
         redo_shortcut.activated.connect(self._on_redo)
+        if app:
+            app.aboutToQuit.connect(self._on_app_quit)
 
 
     def _build_connection_group(self) -> QtWidgets.QGroupBox:
@@ -393,8 +294,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.device_combo = QtWidgets.QComboBox()
         self.device_combo.setVisible(False)
 
-        self.refresh_button.clicked.connect(self._refresh_and_connect)
-        self.read_button.clicked.connect(self._read_settings)
+        self.refresh_button.clicked.connect(
+            lambda _checked=False: self._refresh_and_connect(silent=False))
+        self.read_button.clicked.connect(
+            lambda _checked=False: self._read_settings(silent=False))
         self.export_button.clicked.connect(self._export_profile)
         self.import_button.clicked.connect(self._import_profile)
         
@@ -493,7 +396,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.action_select = QtWidgets.QComboBox()
         self.action_select.addItems([
             "Keyboard Key", "Left Click", "Right Click", "Middle Click", 
-            "Forward", "Back", "Macro", "Reset Defaults",
+            "Forward", "Back", "Macro",
             "Fire Key", "Triple Click", "Media Key", "RGB Toggle", 
             "Polling Rate Toggle", "DPI Control", "Disabled"
         ])
@@ -542,7 +445,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.macro_group = QtWidgets.QWidget()
         macro_layout = QtWidgets.QFormLayout(self.macro_group)
         self.macro_index_spin = QtWidgets.QSpinBox()
-        self.macro_index_spin.setRange(1, 12)
+        self.macro_index_spin.setRange(1, 16)
         macro_layout.addRow("Macro Index:", self.macro_index_spin)
         
         # Macro Repeat Mode
@@ -831,6 +734,17 @@ class MainWindow(QtWidgets.QMainWindow):
                 if idx_count >= 0: self.macro_repeat_combo.setCurrentIndex(idx_count)
             
             self.macro_repeat_count.setValue(params.get("mode", 1) if isinstance(params.get("mode", 1), int) else 1)
+        elif action == "Media Key":
+            index = self.media_select.findData(params.get("code", 0))
+            if index >= 0:
+                self.media_select.setCurrentIndex(index)
+        elif action == "DPI Control":
+            index = self.dpi_action_select.findData(params.get("func", 1))
+            if index >= 0:
+                self.dpi_action_select.setCurrentIndex(index)
+        elif action in ("Fire Key", "Triple Click"):
+            self.special_delay_spin.setValue(params.get("delay", 40))
+            self.special_repeat_spin.setValue(params.get("repeat", 3))
 
     def _update_bind_ui(self, action: str) -> None:
         """Show/hide UI elements based on selected action."""
@@ -838,6 +752,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.macro_group.setVisible(action == "Macro")
         self.special_group.setVisible(action in ["Fire Key", "Triple Click"])
         self.media_group.setVisible(action == "Media Key")
+        self.dpi_group.setVisible(action == "DPI Control")
         
         # Enable/disable repeat count based on repeat mode
         if action == "Macro":
@@ -864,10 +779,10 @@ class MainWindow(QtWidgets.QMainWindow):
                     # Convert keys to int
                     self.macro_names = {int(k): v for k, v in data.items()}
             except Exception as e:
-                self._log(f"Config: Failed to load macro names: {e}")
+                self._config_errors.append(f"Config: Failed to load macro names: {e}")
         
         # Ensure defaults for missing slots
-        for i in range(1, 13):
+        for i in range(1, 17):
             if i not in self.macro_names:
                 self.macro_names[i] = f"Macro {i}"
 
@@ -879,6 +794,45 @@ class MainWindow(QtWidgets.QMainWindow):
                 json.dump(self.macro_names, f, indent=2)
         except Exception as e:
             self._log(f"Config: Failed to save macro names: {e}")
+
+    def _load_app_settings(self) -> None:
+        """Load persistent background-controller preferences."""
+        if not self.settings_file.exists():
+            return
+        try:
+            data = json.loads(self.settings_file.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("settings root must be an object")
+            enabled = bool(data.get("battery_led_enabled", False))
+            restore = data.get("battery_led_restore")
+            parsed_restore = None
+            if isinstance(restore, dict):
+                parsed_restore = {
+                    "r": max(0, min(255, int(restore.get("r", 255)))),
+                    "g": max(0, min(255, int(restore.get("g", 0)))),
+                    "b": max(0, min(255, int(restore.get("b", 255)))),
+                    "mode": max(0, min(3, int(
+                        restore.get("mode", vp.RGB_MODE_STEADY)))),
+                    "brightness": max(0, min(100, int(
+                        restore.get("brightness", 100)))),
+                }
+            self.battery_led_enabled = enabled
+            self._battery_led_restore = parsed_restore
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._config_errors.append(f"Config: Failed to load settings: {exc}")
+
+    def _save_app_settings(self) -> None:
+        """Persist the battery LED preference and its restore lighting."""
+        payload = {
+            "battery_led_enabled": self.battery_led_enabled,
+            "battery_led_restore": self._battery_led_restore,
+        }
+        temporary = self.settings_file.with_suffix(".json.tmp")
+        try:
+            temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            temporary.replace(self.settings_file)
+        except OSError as exc:
+            self._log(f"Config: Failed to save settings: {exc}")
 
     def _build_macros_tab(self) -> QtWidgets.QWidget:
         """Build the visual macro editor tab with event list, recording, and preview."""
@@ -968,8 +922,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         add_layout.addWidget(QtWidgets.QLabel("Key:"))
         self.add_key_combo = QtWidgets.QComboBox()
+        self.add_key_combo.addItem("Mouse: Left Button", ("mouse", 0x01))
+        self.add_key_combo.addItem("Mouse: Right Button", ("mouse", 0x02))
+        self.add_key_combo.addItem("Mouse: Middle Button", ("mouse", 0x04))
+        self.add_key_combo.insertSeparator(self.add_key_combo.count())
         for key_name in sorted(vp.HID_KEY_USAGE.keys(), key=lambda x: (len(x) > 1, x)):
-            self.add_key_combo.addItem(key_name, vp.HID_KEY_USAGE[key_name])
+            self.add_key_combo.addItem(key_name, ("keyboard", vp.HID_KEY_USAGE[key_name]))
         add_layout.addWidget(self.add_key_combo)
 
         add_layout.addWidget(QtWidgets.QLabel("Action:"))
@@ -1011,7 +969,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         bind_layout.addWidget(QtWidgets.QLabel("Macro Index:"), 0, 2)
         self.macro_bind_index_spin = QtWidgets.QSpinBox()
-        self.macro_bind_index_spin.setRange(1, 12)
+        self.macro_bind_index_spin.setRange(1, 16)
         self.macro_bind_index_spin.setValue(1)
         bind_layout.addWidget(self.macro_bind_index_spin, 0, 3)
 
@@ -1066,7 +1024,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def _refresh_macro_list(self) -> None:
         """Refresh the macro list widget."""
         self.macro_list.clear()
-        for i in range(1, 13):
+        for i in range(1, 17):
             name = self.macro_names.get(i, f"Macro {i}")
             item = QtWidgets.QListWidgetItem(f"{i}: {name}")
             item.setData(QtCore.Qt.ItemDataRole.UserRole, i)
@@ -1101,19 +1059,12 @@ class MainWindow(QtWidgets.QMainWindow):
                  QtWidgets.QMessageBox.warning(self, "Duplicate Name", f"Macro name '{name}' is already used by Slot {i}.")
                  return
         
-        # Update Name Dict
-        self.macro_names[index] = name
-        self._save_macro_names()
-        
         # Upload to Device
-        self._upload_macro() # This uses macro_bind_index_spin
-        
-        # Refresh List
-        self._refresh_macro_list()
-        
-        # Clear Staged visual (if any)? 
-        # _upload_macro handles device communication.
-        QtWidgets.QMessageBox.information(self, "Saved", f"Macro '{name}' saved to Slot {index}.")
+        if self._upload_macro():  # Uses macro_bind_index_spin.
+            self.macro_names[index] = name
+            self._save_macro_names()
+            self._refresh_macro_list()
+            self._log(f"Macro '{name}' saved to slot {index}")
 
     def _toggle_recording(self, checked: bool) -> None:
         """Start or stop macro recording."""
@@ -1152,7 +1103,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 # Map Qt key to HID key name
                 key_name = self._qt_key_to_name(qt_key, key_text)
                 if key_name and key_name in vp.HID_KEY_USAGE:
-                    import time
                     current_time = time.time() * 1000  # ms
                     delay = int(current_time - self._last_key_time) if self._last_key_time > 0 else 0
                     delay = min(delay, 5000)  # Cap at 5 seconds
@@ -1203,7 +1153,10 @@ class MainWindow(QtWidgets.QMainWindow):
         }
         return key_map.get(qt_key)
 
-    def _add_event_to_table(self, key_name: str, is_down: bool, delay: int, is_modifier: bool = False) -> None:
+    def _add_event_to_table(self, key_name: str, is_down: bool, delay: int,
+                            is_modifier: bool = False,
+                            event_type: str = "keyboard",
+                            keycode: int | None = None) -> None:
         """Add an event row to the macro event table."""
         row = self.macro_event_table.rowCount()
         self.macro_event_table.insertRow(row)
@@ -1217,6 +1170,9 @@ class MainWindow(QtWidgets.QMainWindow):
         key_item = QtWidgets.QTableWidgetItem(key_name)
         key_item.setFlags(key_item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
         key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 1, is_modifier)  # Store modifier flag
+        key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 2,
+                         "modifier" if is_modifier else event_type)
+        key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 3, keycode)
         self.macro_event_table.setItem(row, 1, key_item)
 
         # Action
@@ -1292,17 +1248,25 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _get_row_data(self, row: int) -> tuple:
         """Get data from a row."""
-        key = self.macro_event_table.item(row, 1).text()
+        key_item = self.macro_event_table.item(row, 1)
+        key = key_item.text()
+        is_modifier = bool(key_item.data(QtCore.Qt.ItemDataRole.UserRole + 1))
+        event_type = key_item.data(QtCore.Qt.ItemDataRole.UserRole + 2) or "keyboard"
+        keycode = key_item.data(QtCore.Qt.ItemDataRole.UserRole + 3)
         action_item = self.macro_event_table.item(row, 2)
         is_down = action_item.data(QtCore.Qt.ItemDataRole.UserRole)
         delay_widget = self.macro_event_table.cellWidget(row, 3)
         delay = delay_widget.value() if delay_widget else 0
-        return (key, is_down, delay)
+        return (key, is_down, delay, is_modifier, event_type, keycode)
 
     def _set_row_data(self, row: int, data: tuple) -> None:
         """Set data in a row."""
-        key, is_down, delay = data
-        self.macro_event_table.item(row, 1).setText(key)
+        key, is_down, delay, is_modifier, event_type, keycode = data
+        key_item = self.macro_event_table.item(row, 1)
+        key_item.setText(key)
+        key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 1, is_modifier)
+        key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 2, event_type)
+        key_item.setData(QtCore.Qt.ItemDataRole.UserRole + 3, keycode)
         action_item = self.macro_event_table.item(row, 2)
         action_item.setText("Press" if is_down else "Release")
         action_item.setData(QtCore.Qt.ItemDataRole.UserRole, is_down)
@@ -1313,9 +1277,14 @@ class MainWindow(QtWidgets.QMainWindow):
     def _add_manual_event(self) -> None:
         """Add an event manually from the add controls."""
         key_name = self.add_key_combo.currentText()
+        event_data = self.add_key_combo.currentData()
+        if not event_data:
+            return
+        event_type, keycode = event_data
         is_down = self.add_action_combo.currentData()
         delay = self.add_delay_spin.value()
-        self._add_event_to_table(key_name, is_down, delay)
+        self._add_event_to_table(key_name, is_down, delay,
+                                 event_type=event_type, keycode=keycode)
 
     def _update_macro_preview(self) -> None:
         """Update the preview label with the macro output."""
@@ -1326,6 +1295,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         for row in range(self.macro_event_table.rowCount()):
             key = self.macro_event_table.item(row, 1).text() if self.macro_event_table.item(row, 1) else ""
+            event_type = (self.macro_event_table.item(row, 1).data(
+                QtCore.Qt.ItemDataRole.UserRole + 2) if self.macro_event_table.item(row, 1) else "keyboard")
             action_item = self.macro_event_table.item(row, 2)
             is_down = action_item.data(QtCore.Qt.ItemDataRole.UserRole) if action_item else True
             delay_widget = self.macro_event_table.cellWidget(row, 3)
@@ -1336,7 +1307,10 @@ class MainWindow(QtWidgets.QMainWindow):
             if is_down:
                 pressed_keys.add(key)
                 # Only add to result for single-char keys to show "typed" output
-                if len(key) == 1:
+                if event_type == "mouse":
+                    mouse_label = key[7:] if key.startswith("Mouse: ") else key
+                    result.append(f"[{mouse_label}]")
+                elif len(key) == 1:
                     result.append(key.lower())
             else:
                 pressed_keys.discard(key)
@@ -1358,14 +1332,22 @@ class MainWindow(QtWidgets.QMainWindow):
             key_name = key_item.text()
             is_down = action_item.data(QtCore.Qt.ItemDataRole.UserRole)
             is_modifier = key_item.data(QtCore.Qt.ItemDataRole.UserRole + 1) or False
+            event_type = key_item.data(QtCore.Qt.ItemDataRole.UserRole + 2) or (
+                "modifier" if is_modifier else "keyboard")
+            stored_keycode = key_item.data(QtCore.Qt.ItemDataRole.UserRole + 3)
             delay = delay_widget.value() if delay_widget else 0
-            
-            if key_name in vp.HID_KEY_USAGE:
+
+            if event_type == "mouse" and stored_keycode is not None:
+                events.append(vp.MacroEvent.mouse(int(stored_keycode), is_down, delay))
+            elif key_name in vp.HID_KEY_USAGE or stored_keycode is not None:
+                keycode = (int(stored_keycode) if stored_keycode is not None
+                           else vp.HID_KEY_USAGE[key_name])
                 events.append(vp.MacroEvent(
-                    keycode=vp.HID_KEY_USAGE[key_name],
+                    keycode=keycode,
                     is_down=is_down,
                     delay_ms=delay,
-                    is_modifier=is_modifier
+                    is_modifier=is_modifier,
+                    event_type=event_type,
                 ))
         return events
 
@@ -1434,10 +1416,30 @@ class MainWindow(QtWidgets.QMainWindow):
         apply_custom_button.setStyleSheet("font-weight: bold; padding: 8px; background-color: #444;")
         apply_custom_button.clicked.connect(self._apply_rgb_custom)
 
+        self.battery_led_checkbox = QtWidgets.QCheckBox(
+            "Use mouse LED as a battery gauge while this app is running")
+        self.battery_led_checkbox.setChecked(self.battery_led_enabled)
+        self.battery_led_checkbox.setToolTip(
+            "Uses the lowest captured steady-light brightness and updates only "
+            "when the mouse reports a different 10% battery step. Green is full, "
+            "yellow is half, and red is empty.")
+        self.battery_led_checkbox.toggled.connect(self._set_battery_led_enabled)
+        gradient_label = QtWidgets.QLabel(
+            '<span style="color:#00ff00">● full</span> → '
+            '<span style="color:#80ff00">●</span> → '
+            '<span style="color:#ffff00">● half</span> → '
+            '<span style="color:#ff8000">●</span> → '
+            '<span style="color:#ff0000">● empty</span>')
+
         form_layout.addRow("Color:", self.rgb_color_button)
         form_layout.addRow("Mode:", self.rgb_mode)
         form_layout.addRow("Brightness:", brightness_layout)
         form_layout.addRow("", apply_custom_button)
+        form_layout.addRow("Battery LED:", self.battery_led_checkbox)
+        form_layout.addRow("", gradient_label)
+
+        if self._battery_led_restore:
+            self._apply_rgb_restore_to_widgets(self._battery_led_restore)
         
         layout.addWidget(form_widget)
         layout.addStretch()
@@ -1452,6 +1454,23 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         # Optionally auto-apply?
         # self._apply_rgb_custom()
+
+    def _capture_rgb_restore(self) -> dict[str, int]:
+        return {
+            "r": self.rgb_current_color.red(),
+            "g": self.rgb_current_color.green(),
+            "b": self.rgb_current_color.blue(),
+            "mode": int(self.rgb_mode.currentData() or vp.RGB_MODE_OFF),
+            "brightness": self.rgb_brightness.value(),
+        }
+
+    def _apply_rgb_restore_to_widgets(self, settings: dict[str, int]) -> None:
+        color = QtGui.QColor(settings["r"], settings["g"], settings["b"])
+        self._set_custom_color(color)
+        mode_index = self.rgb_mode.findData(settings["mode"])
+        if mode_index >= 0:
+            self.rgb_mode.setCurrentIndex(mode_index)
+        self.rgb_brightness.setValue(settings["brightness"])
 
 
     def _pick_rgb_color(self) -> None:
@@ -1481,7 +1500,9 @@ class MainWindow(QtWidgets.QMainWindow):
         widget = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout(widget)
 
-        header = QtWidgets.QLabel("DPI slots (presets match factory defaults; custom uses computed values)")
+        header = QtWidgets.QLabel(
+            "DPI slots (presets are captured values; custom conversion is approximate and sensor-dependent)")
+        header.setWordWrap(True)
         layout.addWidget(header)
 
         self.dpi_rows: list[tuple[
@@ -1621,42 +1642,280 @@ class MainWindow(QtWidgets.QMainWindow):
     def _log(self, text: str) -> None:
         self.log_area.appendPlainText(text)
 
+    def _battery_icon(self, percent: int | None, cable_connected: bool = False) -> QtGui.QIcon:
+        pixmap = QtGui.QPixmap(64, 64)
+        pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+        painter = QtGui.QPainter(pixmap)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+
+        outline = QtGui.QColor("#e6e6e6")
+        if percent is None:
+            fill = QtGui.QColor("#777777")
+        else:
+            fill = QtGui.QColor(*vp.battery_gradient_rgb(percent))
+
+        pen = QtGui.QPen(outline, 4)
+        painter.setPen(pen)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        body = QtCore.QRectF(6, 14, 46, 36)
+        painter.drawRoundedRect(body, 5, 5)
+        painter.fillRect(QtCore.QRectF(53, 24, 6, 16), outline)
+
+        if percent is not None:
+            inner_width = 38 * max(0, min(100, percent)) / 100
+            painter.fillRect(QtCore.QRectF(10, 18, inner_width, 28), fill)
+        else:
+            painter.setPen(outline)
+            font = painter.font()
+            font.setBold(True)
+            font.setPixelSize(25)
+            painter.setFont(font)
+            painter.drawText(body, QtCore.Qt.AlignmentFlag.AlignCenter, "?")
+
+        if cable_connected:
+            painter.setPen(QtGui.QPen(QtGui.QColor("#ffffff"), 3))
+            painter.drawLine(32, 10, 25, 30)
+            painter.drawLine(25, 30, 34, 30)
+            painter.drawLine(34, 30, 27, 52)
+        painter.end()
+        return QtGui.QIcon(pixmap)
+
+    def _setup_tray(self) -> None:
+        """Create one desktop-neutral Qt status icon and refresh timer."""
+        self.tray_icon: QtWidgets.QSystemTrayIcon | None = None
+        self.battery_timer = QtCore.QTimer(self)
+        self.battery_timer.setInterval(60_000)
+        self.battery_timer.timeout.connect(self._request_battery_refresh)
+        self.battery_timer.start()
+        self.battery_led_tray_action: QtGui.QAction | None = None
+
+        if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
+            self._log("Tray: This desktop session does not expose a system tray.")
+            self._sync_battery_led_controls()
+            return
+
+        self.tray_icon = QtWidgets.QSystemTrayIcon(self._battery_icon(None), self)
+        self.tray_icon.setToolTip("Venus mouse — battery unavailable")
+        menu = QtWidgets.QMenu(self)
+        show_action = menu.addAction("Show Venus Pro Config")
+        show_action.triggered.connect(self._show_from_tray)
+        refresh_action = menu.addAction("Refresh Battery")
+        refresh_action.triggered.connect(self._request_battery_refresh)
+        self.battery_led_tray_action = menu.addAction(
+            "Battery-color mouse LED (minimum brightness)")
+        self.battery_led_tray_action.setCheckable(True)
+        self.battery_led_tray_action.triggered.connect(
+            self._set_battery_led_enabled)
+        menu.addSeparator()
+        quit_action = menu.addAction("Quit")
+        quit_action.triggered.connect(self._quit_from_tray)
+        self.tray_icon.setContextMenu(menu)
+        self.tray_icon.activated.connect(self._tray_activated)
+        self.tray_icon.show()
+        self._sync_battery_led_controls()
+
+        app = QtWidgets.QApplication.instance()
+        if app:
+            app.setQuitOnLastWindowClosed(False)
+
+    def _sync_battery_led_controls(self) -> None:
+        supported = self.device_type == "venus_pro"
+        if hasattr(self, "battery_led_checkbox"):
+            self.battery_led_checkbox.blockSignals(True)
+            self.battery_led_checkbox.setChecked(self.battery_led_enabled)
+            self.battery_led_checkbox.setEnabled(supported)
+            self.battery_led_checkbox.blockSignals(False)
+        if self.battery_led_tray_action:
+            self.battery_led_tray_action.blockSignals(True)
+            self.battery_led_tray_action.setChecked(self.battery_led_enabled)
+            self.battery_led_tray_action.setEnabled(supported)
+            self.battery_led_tray_action.blockSignals(False)
+
+    def _set_battery_led_enabled(self, enabled: bool,
+                                 restore: bool = True) -> None:
+        """Toggle the background battery-color controller."""
+        enabled = bool(enabled)
+        if enabled and self.device_type != "venus_pro":
+            self._sync_battery_led_controls()
+            return
+        if enabled == self.battery_led_enabled:
+            self._sync_battery_led_controls()
+            return
+
+        was_enabled = self.battery_led_enabled
+        if enabled:
+            self._battery_led_restore = self._capture_rgb_restore()
+            self.battery_led_enabled = True
+            self._last_battery_led_level = None
+            self._log(
+                "Battery LED: enabled (minimum brightness; updates on battery-step changes)")
+        else:
+            self.battery_led_enabled = False
+            self._last_battery_led_level = None
+            self._log("Battery LED: disabled")
+
+        self._save_app_settings()
+        self._sync_battery_led_controls()
+        if enabled:
+            self._request_battery_refresh()
+        elif was_enabled and restore:
+            self._restore_battery_led(quiet=False)
+
+    def _restore_battery_led(self, quiet: bool) -> bool:
+        """Restore lighting captured when battery mode was enabled."""
+        settings = self._battery_led_restore
+        self._last_battery_led_level = None
+        if not settings:
+            return True
+        if hasattr(self, "rgb_mode"):
+            self._apply_rgb_restore_to_widgets(settings)
+        if self.device_type != "venus_pro" or self.device_path is None:
+            return True
+        packet = vp.build_rgb(
+            settings["r"], settings["g"], settings["b"],
+            settings["mode"], settings["brightness"])
+        return self._send_reports(
+            [vp.build_simple(vp.CMD_READY), packet],
+            "Battery LED restore", quiet=quiet)
+
+    def _on_app_quit(self) -> None:
+        if self._shutdown_restore_done:
+            return
+        self._shutdown_restore_done = True
+        self._quitting = True
+        self.battery_timer.stop()
+        if self._battery_thread and self._battery_thread.isRunning():
+            # open() may wait one second for the shared HID lock before the
+            # status exchange uses its own 500 ms timeout.
+            self._battery_thread.wait(2000)
+        if self.battery_led_enabled:
+            self._restore_battery_led(quiet=True)
+        if self.tray_icon:
+            self.tray_icon.hide()
+
+    def _apply_battery_led_status(self, status: vp.BatteryStatus) -> None:
+        if (not self.battery_led_enabled or self._quitting or
+                status.level == self._last_battery_led_level):
+            return
+        r, g, b = vp.battery_gradient_rgb(status.percent)
+        success = self._send_reports(
+            [vp.build_simple(vp.CMD_READY),
+             vp.build_battery_indicator_rgb(status.percent)],
+            f"Battery LED {status.percent}% ({r},{g},{b})",
+            quiet=True)
+        if success:
+            self._last_battery_led_level = status.level
+            self._log(
+                f"Battery LED: {status.percent}% -> RGB({r}, {g}, {b}) at minimum brightness")
+
+    def _show_from_tray(self) -> None:
+        self.showNormal()
+        self.raise_()
+        self.activateWindow()
+
+    def _tray_activated(self, reason) -> None:
+        if reason in (QtWidgets.QSystemTrayIcon.ActivationReason.Trigger,
+                      QtWidgets.QSystemTrayIcon.ActivationReason.DoubleClick):
+            self._show_from_tray()
+
+    def _quit_from_tray(self) -> None:
+        self._quitting = True
+        self.battery_timer.stop()
+        if self.tray_icon:
+            self.tray_icon.hide()
+        app = QtWidgets.QApplication.instance()
+        if app:
+            app.quit()
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+        if self.tray_icon and self.tray_icon.isVisible() and not self._quitting:
+            event.ignore()
+            self.hide()
+            if not self._tray_notice_shown:
+                self.tray_icon.showMessage(
+                    "Venus Pro Config",
+                    "Battery monitoring is still running. Use the tray menu to quit.",
+                    QtWidgets.QSystemTrayIcon.MessageIcon.Information,
+                    3500,
+                )
+                self._tray_notice_shown = True
+            return
+        super().closeEvent(event)
+
+    def _request_battery_refresh(self) -> None:
+        if not self.tray_icon and not self.battery_led_enabled:
+            return
+        if self.device_type != "venus_pro" or self.device_path is None:
+            if self.tray_icon:
+                self.tray_icon.setIcon(self._battery_icon(None))
+                self.tray_icon.setToolTip("Venus mouse — battery unavailable")
+            return
+        if self._battery_thread and self._battery_thread.isRunning():
+            return
+        self._battery_thread = BatteryQueryThread(self.device_path, self)
+        self._battery_thread.completed.connect(self._battery_query_finished)
+        self._battery_thread.start()
+
+    def _battery_query_finished(self, status: object, error: str) -> None:
+        thread = self._battery_thread
+        self._battery_thread = None
+        if thread:
+            thread.deleteLater()
+        if isinstance(status, vp.BatteryStatus):
+            connection = "USB cable" if status.cable_connected else "wireless"
+            current = (status.level, status.cable_connected)
+            if current != self._last_battery_status:
+                self._log(f"Battery: {status.percent}% ({connection})")
+                self._last_battery_status = current
+            if self.tray_icon:
+                suffix = "; battery LED on" if self.battery_led_enabled else ""
+                self.tray_icon.setIcon(
+                    self._battery_icon(status.percent, status.cable_connected))
+                self.tray_icon.setToolTip(
+                    f"Venus Pro — {status.percent}% ({connection}{suffix})")
+            self._apply_battery_led_status(status)
+        else:
+            if self.tray_icon:
+                self.tray_icon.setIcon(self._battery_icon(None))
+                self.tray_icon.setToolTip(
+                    "Venus Pro — disconnected or inaccessible")
+            if error:
+                self._log(f"Battery refresh: {error}")
+
     def _refresh_devices(self) -> None:
         self.device_infos = vp.list_devices()
         self.device_combo.clear()
-        
-        # Check for busy/captured devices via PyUSB
-        wired_on_bus = False
-        wireless_on_bus = False
-        if vp.PYUSB_AVAILABLE:
-            import usb.core
-            wired_on_bus = usb.core.find(idVendor=vp.VENDOR_IDS[0], idProduct=vp.PRODUCT_IDS[1]) is not None
-            wireless_on_bus = usb.core.find(idVendor=vp.VENDOR_IDS[0], idProduct=vp.PRODUCT_IDS[0]) is not None
 
-        # Check if wired mouse is missing from hidapi but present on bus
-        wired_found = any(d.product_id == vp.PRODUCT_IDS[1] for d in self.device_infos)
-        
-        if wired_on_bus and not wired_found:
-            self.status_label.setText("Status: Wired Mouse BUSY (Captured by Wine/VM?)")
+        if not vp.HIDAPI_AVAILABLE:
+            self.status_label.setText("Status: python-hidapi is not installed")
             self.status_label.setStyleSheet("color: orange; font-weight: bold;")
-            self._log("Refresh: Wired mouse found on bus but not accessible via HID. Likely captured.")
-        elif not self.device_infos:
-            self.status_label.setText("Status: No device found")
-            self.status_label.setStyleSheet("")
-            self.device_combo.addItem("No Venus Pro devices found")
+            self.device_combo.addItem("Install python-hidapi")
             self.device_path = None
             return
+
+        if not self.device_infos:
+            self.status_label.setText("Status: No device found")
+            self.status_label.setStyleSheet("")
+            self.device_combo.addItem("No supported vendor HID interface found")
+            self.device_path = None
+            return
+
+        for info in self.device_infos:
+            access = " — inaccessible" if info.access_error else ""
+            label = (f"{info.product} (0x{info.vendor_id:04x}:0x{info.product_id:04x}, "
+                     f"interface {info.interface_number}){access}")
+            self.device_combo.addItem(label, info)
+
+        chosen = next((item for item in self.device_infos if not item.access_error),
+                      self.device_infos[0])
+        self.device_path = chosen.path
+        if chosen.access_error:
+            self.status_label.setText("Status: Mouse detected, but access failed")
+            self.status_label.setStyleSheet("color: orange; font-weight: bold;")
+            self._log(f"Detection: {chosen.access_error}")
         else:
             self.status_label.setStyleSheet("")
             self.status_label.setText("Status: Ready")
-
-        for info in self.device_infos:
-            label = f"{info.product} (0x{info.product_id:04x}) {info.serial}".strip()
-            self.device_combo.addItem(label, info)
-        
-        if self.device_infos:
-            # Store path of first device for transient connections
-            self.device_path = self.device_infos[0].path
 
     def _connect_device(self) -> None:
         """Legacy function - now just stores device path."""
@@ -1669,7 +1928,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self.device_path = info.path
         self.status_label.setText(f"Ready: {info.product}")
-        self._log(f"Device selected: {info.product} ({info.serial})")
+        self._log(f"Device selected: {info.product} ({info.display_path})")
 
     def _disconnect_device(self) -> None:
         """Legacy function - just clears device path."""
@@ -1677,12 +1936,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.status_label.setText("Disconnected")
         self._log("Device cleared")
 
-    def _refresh_and_connect(self) -> None:
+    def _refresh_and_connect(self, silent: bool = False) -> None:
         """Refresh devices and store path for transient connections."""
         self._log("Connect: Refreshing device list...")
         self._refresh_devices()
         if self.device_infos:
-            info = self.device_infos[0]
+            info = next((item for item in self.device_infos if not item.access_error),
+                        self.device_infos[0])
             self.device_path = info.path
 
             # Detect device type and swap profiles
@@ -1691,12 +1951,17 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._log(f"Connect: Device type changed: {self.device_type} -> {new_type}")
             self.device_type = new_type
             self.active_button_profiles = dd.get_button_profiles(self.device_type)
+            self._last_battery_led_level = None
+            self._last_battery_status = None
+            self._sync_battery_led_controls()
             self._rebuild_button_table()
 
             device_name = vp.DEVICE_NAMES.get((info.vendor_id, info.product_id), info.product)
             self.status_label.setText(f"Ready: {device_name}")
-            self.setWindowTitle(f"Venus Config v0.2.1 — {device_name}")
-            self._log(f"Connect: Found {device_name} ({self.device_type}) at {info.path}")
+            self.setWindowTitle(f"Venus Pro Config — {device_name}")
+            self._log(f"Connect: Found {device_name} ({self.device_type}) at {info.display_path}")
+            if info.selection_note:
+                self._log(f"Connect: {info.selection_note}")
 
             # Show/hide profile selector for Holtek
             is_holtek = self.device_type == 'holtek'
@@ -1708,12 +1973,18 @@ class MainWindow(QtWidgets.QMainWindow):
 
             QtWidgets.QApplication.processEvents()
 
-            # Auto-read settings on startup
-            self._log("Connect: Triggering auto-read settings...")
-            self._read_settings()
+            if info.access_error:
+                self.status_label.setText(f"Detected: {device_name} — access denied")
+                self._log(f"Connect: {info.access_error}")
+            else:
+                # Auto-read settings on startup
+                self._log("Connect: Triggering auto-read settings...")
+                self._read_settings(silent=silent)
+                self._request_battery_refresh()
         else:
             self._log("Connect: No devices found.")
             self.status_label.setText("No device found")
+            self._request_battery_refresh()
 
     def _auto_connect(self) -> None:
         """Legacy function - handled by _refresh_and_connect now."""
@@ -1774,14 +2045,16 @@ class MainWindow(QtWidgets.QMainWindow):
         return True
 
 
-    def _send_reports(self, reports: list[bytes], label: str) -> None:
+    def _send_reports(self, reports: list[bytes], label: str,
+                      quiet: bool = False) -> bool:
         """Send reports using a transient device connection."""
-        if not self._require_device():
-            return
+        if quiet and self.device_path is None:
+            return False
+        if not quiet and not self._require_device():
+            return False
 
         device = None
         try:
-            import time
             # Open device transiently using factory
             device = dd.create_device(self.device_type, self.device_path)
             device.open()
@@ -1791,9 +2064,15 @@ class MainWindow(QtWidgets.QMainWindow):
                     self._log(f"{label}: {report.hex()}")
                 else:
                     self._log(f"TIMEOUT: {report.hex()}")
-                    raise RuntimeError(f"Device timed out on command {report[1]:02X}")
+                    raise RuntimeError(
+                        getattr(device, "last_error", "") or
+                        f"Device timed out on command {report[1]:02X}")
+            return True
         except Exception as exc:
-            QtWidgets.QMessageBox.critical(self, "Send failed", str(exc))
+            self._log(f"{label}: {exc}")
+            if not quiet:
+                QtWidgets.QMessageBox.critical(self, "Send failed", str(exc))
+            return False
         finally:
             # Always close the device
             if device:
@@ -1801,114 +2080,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
 
     def _sync_all_buttons(self) -> None:
-        """Sync ALL cached button assignments to the device (Reset + Upload)."""
-        if not self.device_path: return
-
-        # Progress Dialog
-        progress = QtWidgets.QProgressDialog("Syncing... (Resetting Device)", "Cancel", 0, 100, self)
-        progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
-        progress.show()
-        
-        try:
-            reports = []
-            # 1. Prepare (Cmd 04) - Matches working Windows sequence
-            reports.append(vp.build_simple(0x04))
-            
-            # 2. Build Packets
-            # Use sorted keys for deterministic packet order
-            keys = sorted(self.button_assignments.keys(), key=lambda k: int(k.split()[1]))
-            
-            for key in keys:
-                assign = self.button_assignments[key]
-                action = assign["action"]
-                params = assign["params"]
-                
-                # Resolve addresses
-                code_hi_base, code_lo, apply_offset_base = self._resolve_profile(key, use_fallback=True)
-                profile_pages = [0x00] # Only Page 0 needed for Binds? 
-                # Wait. Key Defs are on Page 1 (0x00+0x00 = 0x00? No, Code Hi is 0x01/0x02).
-                # Current logic used loop [0x00, 0x40, 0x80, 0xC0] to support profiles.
-                # Let's stick to that to be robust.
-                profile_pages = [0x00, 0x40, 0x80, 0xC0]
-                
-                for page in profile_pages:
-                    current_code_hi = code_hi_base + page
-                    
-                    if action == "Keyboard Key":
-                        hid_key = params.get("key", 0)
-                        modifier = params.get("mod", 0)
-                        # Page 1 Write (Key Def)
-                        reports.extend(vp.build_key_binding(current_code_hi, code_lo, hid_key, modifier))
-                        # Page 0 Bind (Type 05)
-                        reports.append(vp.build_keyboard_bind(apply_offset_base, page=page))
-
-                    elif action == "Disabled":
-                        reports.append(vp.build_disabled(apply_offset_base, page=page))
-                        
-                    elif action in ["Left Click", "Right Click", "Middle Click", "Forward", "Back"]:
-                         val_map = {"Left Click": 0x01, "Right Click": 0x02, "Middle Click": 0x04, "Back": 0x08, "Forward": 0x10}
-                         val = val_map.get(action, 0)
-                         reports.append(vp.build_mouse_param(apply_offset_base, val, page=page))
-                    
-                    elif action == "DPI Control":
-                         func_id = params.get("func", 1) # 1=Loop, 2=+, 3=-
-                         dummy_key = 0x23 if func_id==1 else (0x24 if func_id==2 else 0x25)
-                         reports.extend(vp.build_key_binding(current_code_hi, code_lo, dummy_key, 0))
-                         reports.append(vp.build_apply_binding(apply_offset_base, action_type=2, action_code=0x50, modifier=func_id, page=page))
-
-                    elif action in ["Fire Key", "Triple Click"]:
-                         delay = params.get("delay", 40)
-                         rep = params.get("repeat", 3)
-                         reports.append(vp.build_special_binding(apply_offset_base, delay, rep, page=page))
-                    
-                    elif action == "Media Key":
-                         reports.append(vp.build_apply_binding(apply_offset_base, action_type=5, action_code=0x51, page=page))
-                    
-                    elif action == "Macro":
-                         idx = params.get("index", 1)
-                         mode = params.get("mode", vp.MACRO_REPEAT_ONCE)
-                         reports.append(vp.build_macro_bind(apply_offset_base, idx-1, mode, page=page))
-
-            # 3. Commit
-            reports.append(vp.build_simple(0x04))
-            
-            # SYNC SEQUENCE
-            if self.device_path:
-                mouse = vp.VenusDevice(self.device_path)
-                mouse.open()
-                try:
-                    # 1. Prepare (Cmd 04)
-                    self._log("Readying device for sync...")
-                    if not mouse.send_reliable(vp.build_simple(0x04)):
-                        raise RuntimeError("Sync Timeout: Prepare (0x04)")
-
-                    # 2. Handshake (Cmd 03)
-                    if not mouse.send_reliable(vp.build_simple(0x03)):
-                        self._log("Sync failed: Handshake (0x03) timed out.")
-                        raise RuntimeError("Sync Timeout: Handshake (0x03)")
-                    
-                    # 3. Send All Packets
-                    total_pkts = len(reports)
-                    for i, r in enumerate(reports):
-                        if not mouse.send_reliable(r):
-                            raise RuntimeError(f"Sync Timeout: Packet {i} ({r.hex()})")
-                        
-                        if i % 5 == 0:
-                            pct = int((i / total_pkts) * 100)
-                            progress.setValue(pct)
-                            QtWidgets.QApplication.processEvents()
-                            self._log(f"Sync: {r.hex()}")
-                    
-                    progress.setValue(100)
-                    self._log("Sync Complete.")
-                finally:
-                    mouse.close()
-            
-        except Exception as e:
-            self._log(f"Sync Error: {e}")
-            QtWidgets.QMessageBox.critical(self, "Sync Error", str(e))
-        finally:
-            progress.close()
+        """Stage the cached assignments and use the normal transaction path."""
+        for key, assignment in self.button_assignments.items():
+            self.staging_manager.stage_change(
+                key, assignment["action"], assignment.get("params", {}))
+        self._update_staged_visuals()
+        self._commit_staged_changes()
 
 
     def _auto_stage_binding(self) -> None:
@@ -2014,7 +2191,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         elif action == "Macro":
             index = params.get("index", 1)
-            # mode is either a constant (1=Once, 2=Count?, F0=Hold, F1=Toggle) or raw count
+            # Mode is once/hold/toggle, or a raw repeat count (1..253).
             mode_val = params.get("mode", 1)
             
             mode_str = "Custom"
@@ -2138,12 +2315,15 @@ class MainWindow(QtWidgets.QMainWindow):
             # Holtek: enter write mode before sending packets
             if self.device_type == 'holtek':
                 device.enter_write_mode()
+            elif not device.begin_write():
+                raise RuntimeError(device.last_error or "Mouse did not enter ready state")
 
             builder = PacketBuilder(self)
             controller = TransactionController(device, builder, logger=self._log)
 
             # Progress dialog
-            progress = QtWidgets.QProgressDialog("Applying changes...", "Cancel", 0, 0, self)
+            progress = QtWidgets.QProgressDialog(
+                "Applying changes...", None, 0, 0, self)
             progress.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             progress.show()
 
@@ -2180,7 +2360,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._update_staged_visuals()
                 QtWidgets.QMessageBox.information(self, "Success", "All changes applied successfully.")
             else:
-                QtWidgets.QMessageBox.critical(self, "Error", "Failed to apply changes. Device might be disconnected.")
+                QtWidgets.QMessageBox.critical(
+                    self, "Partial Write Possible",
+                    "A write failed. Earlier acknowledged changes may already be stored on the device; read settings again before retrying.")
                 
         except Exception as e:
             QtWidgets.QMessageBox.critical(self, "Error", str(e))
@@ -2201,123 +2383,80 @@ class MainWindow(QtWidgets.QMainWindow):
                                           profile=self.holtek_profile)
 
         reports = []
-        # Resolve addresses
-        # Note: This logic duplicates _sync_all_buttons. Should eventually replace it.
-        code_hi_base, code_lo, apply_offset_base = self._resolve_profile(key, use_fallback=True)
-        profile_pages = [0x00, 0x40, 0x80, 0xC0]
-        
-        for page in profile_pages:
-            current_code_hi = code_hi_base + page
-            
-            if action == "Keyboard Key":
-                hid_key = params.get("key", 0)
-                modifier = params.get("mod", 0)
-                # Page 1 Write (Key Def)
-                reports.extend(vp.build_key_binding(current_code_hi, code_lo, hid_key, modifier))
-                # Page 0 Bind (Type 05)
-                reports.append(vp.build_keyboard_bind(apply_offset_base, page=page))
+        code_hi, code_lo, apply_offset = self._resolve_profile(key, use_fallback=True)
 
-            elif action == "Disabled":
-                reports.append(vp.build_disabled(apply_offset_base, page=page))
-                
-            elif action in ["Left Click", "Right Click", "Middle Click", "Forward", "Back"]:
-                 val_map = {"Left Click": 0x01, "Right Click": 0x02, "Middle Click": 0x04, "Back": 0x08, "Forward": 0x10}
-                 val = val_map.get(action, 0)
-                 reports.append(vp.build_mouse_param(apply_offset_base, val, page=page))
-            
-            elif action == "DPI Control":
-                 func_id = params.get("func", 1) # 1=Loop, 2=+, 3=-
-                 dummy_key = 0x23 if func_id==1 else (0x24 if func_id==2 else 0x25)
-                 reports.extend(vp.build_key_binding(current_code_hi, code_lo, dummy_key, 0))
-                 reports.append(vp.build_apply_binding(apply_offset_base, action_type=2, action_code=0x50, modifier=func_id, page=page))
-
-            elif action in ["Fire Key", "Triple Click"]:
-                 delay = params.get("delay", 40)
-                 rep = params.get("repeat", 3)
-                 reports.append(vp.build_special_binding(apply_offset_base, delay, rep, page=page))
-            
-            elif action == "Media Key":
-                 reports.append(vp.build_apply_binding(apply_offset_base, action_type=5, action_code=0x51, page=page))
-            
-            elif action == "Macro":
-                 idx = params.get("index", 1)
-                 mode = params.get("mode", vp.MACRO_REPEAT_ONCE)
-                 reports.append(vp.build_macro_bind(apply_offset_base, idx-1, mode, page=page))
+        if action == "Keyboard Key":
+            reports.extend(vp.build_key_binding(
+                code_hi, code_lo, params.get("key", 0), params.get("mod", 0)))
+            reports.append(vp.build_keyboard_bind(apply_offset))
+        elif action == "Media Key":
+            reports.extend(vp.build_consumer_binding(
+                code_hi, code_lo, params.get("code", 0)))
+            reports.append(vp.build_keyboard_bind(apply_offset))
+        elif action == "Disabled":
+            reports.append(vp.build_disabled(apply_offset))
+        elif action in ["Left Click", "Right Click", "Middle Click", "Forward", "Back"]:
+            val_map = {"Left Click": 0x01, "Right Click": 0x02,
+                       "Middle Click": 0x04, "Back": 0x08, "Forward": 0x10}
+            reports.append(vp.build_mouse_param(apply_offset, val_map[action]))
+        elif action == "DPI Control":
+            reports.append(vp.build_dpi_control(apply_offset, params.get("func", 1)))
+        elif action in ["Fire Key", "Triple Click"]:
+            reports.append(vp.build_special_binding(
+                apply_offset, params.get("delay", 40), params.get("repeat", 3)))
+        elif action == "Polling Rate Toggle":
+            reports.append(vp.build_poll_rate_toggle(apply_offset))
+        elif action == "RGB Toggle":
+            reports.append(vp.build_rgb_toggle(apply_offset))
+        elif action == "Macro":
+            reports.append(vp.build_macro_bind(
+                apply_offset, params.get("index", 1) - 1,
+                params.get("mode", vp.MACRO_REPEAT_ONCE)))
+        else:
+            raise ValueError(f"Unsupported button action: {action}")
                  
         return reports
 
 
-    def _upload_macro(self) -> None:
+    def _upload_macro(self) -> bool:
         """Collect current macro and upload to device."""
         if not self.device_path:
-            return
+            return False
         
         macro_index = self.macro_bind_index_spin.value() - 1  # 0-indexed internally
-        if macro_index < 0 or macro_index > 11:
-            QtWidgets.QMessageBox.warning(self, "Invalid", "Macro Index must be 1-12.")
-            return
+        if macro_index < 0 or macro_index > 15:
+            QtWidgets.QMessageBox.warning(self, "Invalid", "Macro Index must be 1-16.")
+            return False
         try:
             # 1. Collect events from table
             raw_events = self._get_macro_events_from_table()
             if not raw_events:
                 QtWidgets.QMessageBox.warning(self, "Error", "No valid events to upload.")
-                return
+                return False
 
-            has_modifier = any(ev.is_modifier for ev in raw_events)
-            has_release = any(not ev.is_down for ev in raw_events)
-            if has_modifier:
-                events = list(raw_events)
-            else:
-                # Normalize to clean down/up pairs using key-down events only.
-                if has_release:
-                    self._log("Normalizing macro to clean down/up pairs.")
-                events = []
-                for ev in raw_events:
-                    if not ev.is_down:
-                        continue
-                    events.append(vp.MacroEvent(ev.keycode, True, ev.delay_ms, False))
-                    events.append(vp.MacroEvent(ev.keycode, False, ev.delay_ms, False))
+            # Preserve the editor's explicit press/release stream.  Rebuilding
+            # it from key-down rows destroyed mouse events and intentionally
+            # overlapping key sequences.
+            events = list(raw_events)
 
             if not events:
                 QtWidgets.QMessageBox.warning(self, "Error", "No valid events to upload.")
-                return
+                return False
 
             # Ensure last event delay = 3ms end marker.
             last = events[-1]
-            events[-1] = vp.MacroEvent(last.keycode, last.is_down, 3, last.is_modifier)
+            events[-1] = vp.MacroEvent(last.keycode, last.is_down, 3,
+                                       last.is_modifier, last.event_type)
+
+            if len(events) > vp.MACRO_MAX_EVENTS:
+                QtWidgets.QMessageBox.warning(
+                    self, "Too Many Events",
+                    f"A hardware macro slot holds at most {vp.MACRO_MAX_EVENTS} events.")
+                return False
             
             # 2. Build macro data buffer
-            macro_name = self.macro_name_edit.text()[:15] or "Macro"
-            name_utf16 = macro_name.encode('utf-16-le')
-            name_len = len(name_utf16)
-            name_padded = name_utf16.ljust(30, b'\x00')[:30]
-
-            # Header structure (32 bytes total):
-            # [0x00]: Name length in bytes
-            # [0x01-0x1E]: Name in UTF-16LE (30 bytes, padded)
-            # [0x1F]: Event count (actual number of events)
-            event_count = len(events)
-            header = bytes([name_len]) + name_padded + bytes([event_count])
-
-            # Event data starts at offset 0x20 (32)
-            event_data = b''.join(ev.to_bytes() for ev in events)
-
-            # Full macro buffer (header + events)
-            full_macro = header + event_data
-
-            # 3. Calculate terminator checksum
-            chk = vp.calculate_terminator_checksum(
-                full_macro,
-                event_count=event_count,
-            )
-            
-            # Terminator is 4 bytes: [checksum] [00] [00] [00]
-            terminator = bytes([chk, 0x00, 0x00, 0x00])
-            full_macro += terminator
-
-            # Pad to 10-byte boundary (AFTER adding terminator)
-            pad_len = (10 - (len(full_macro) % 10)) % 10
-            full_macro += bytes(pad_len)
+            macro_name = self.macro_name_edit.text() or "Macro"
+            full_macro = vp.build_macro_image(macro_name, events)
             
             # Get slot address
             page, offset = vp.get_macro_slot_info(macro_index)
@@ -2325,10 +2464,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._log(f"Uploading Macro {macro_index+1} ({macro_name}) to Page 0x{page:02X} Offset 0x{offset:02X}...")
             
             # Build reports
-            reports = [
-                vp.build_simple(0x04),  # Prepare
-                vp.build_simple(0x03)   # Handshake
-            ]
+            reports = [vp.build_simple(vp.CMD_READY)]
             
             # Split into 10-byte chunks
             addr = (page << 8) | offset
@@ -2339,15 +2475,18 @@ class MainWindow(QtWidgets.QMainWindow):
                 chunk_off = chunk_addr & 0xFF
                 reports.append(vp.build_macro_chunk(chunk_off, chunk, chunk_page))
             
-            # Commit
-            reports.append(vp.build_simple(0x04))
-            
-            self._send_reports(reports, f"Macro {macro_index+1} Upload ({len(full_macro)} bytes)")
-            QtWidgets.QMessageBox.information(self, "Success", f"Macro {macro_index+1} uploaded successfully!")
+            success = self._send_reports(
+                    reports,
+                    f"Macro {macro_index+1} Upload ({len(full_macro)} bytes)")
+            if success:
+                QtWidgets.QMessageBox.information(
+                    self, "Success", f"Macro {macro_index+1} uploaded successfully!")
+            return success
 
         except Exception as e:
             self._log(f"Macro Upload Error: {e}")
             QtWidgets.QMessageBox.critical(self, "Upload Error", str(e))
+            return False
 
     def _bind_macro_to_button(self) -> None:
         """Rebind an already-uploaded macro to a different button using Sync logic."""
@@ -2358,24 +2497,31 @@ class MainWindow(QtWidgets.QMainWindow):
         macro_index = self.macro_bind_index_spin.value()
         repeat_mode = self.macro_tab_repeat_combo.currentData()
         repeat_count = self.macro_tab_repeat_count_spin.value()
+        effective_repeat = repeat_count if repeat_mode == vp.MACRO_REPEAT_COUNT else repeat_mode
         
         # update central state
         self.button_assignments[button_key] = {
             "action": "Macro", 
-            "params": {"index": macro_index, "mode": repeat_mode, "count": repeat_count}
+            "params": {"index": macro_index, "mode": effective_repeat,
+                       "count": repeat_count}
         }
+        self.staging_manager.stage_change(
+            button_key, "Macro",
+            {"index": macro_index, "mode": effective_repeat})
+        self._update_staged_visuals()
         
         # Give feedback
         QtWidgets.QMessageBox.information(self, "Binding", f"Queueing Bind: {button_key} -> Macro {macro_index}.\nSyncing now...")
         
-        # Sync
-        self._sync_all_buttons()
+        self._commit_staged_changes()
 
 
     def _apply_rgb_preset(self) -> None:
+        if self.battery_led_enabled and self.device_type == "venus_pro":
+            self._set_battery_led_enabled(False, restore=False)
         preset_key = self.rgb_select.currentText()
         payload = vp.RGB_PRESETS[preset_key]
-        reports = [vp.build_simple(0x03), vp.build_report(0x07, payload), vp.build_simple(0x04)]
+        reports = [vp.build_simple(vp.CMD_READY), vp.build_report(vp.CMD_WRITE, payload)]
         self._send_reports(reports, f"RGB Preset: {preset_key}")
 
     def _apply_rgb_custom(self) -> None:
@@ -2390,9 +2536,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.device_type == 'holtek':
             return self._apply_rgb_holtek(r, g, b, mode, brightness)
 
+        if self.battery_led_enabled:
+            self._set_battery_led_enabled(False, restore=False)
+
         rgb_packet = vp.build_rgb(r, g, b, mode, brightness)
-        # Sequence based on confirmed captures: 03 (Handshake), [RGB Data], 04 (Commit)
-        reports = [vp.build_simple(0x03), rgb_packet, vp.build_simple(0x04)]
+        reports = [vp.build_simple(vp.CMD_READY), rgb_packet]
 
         mode_name = self.rgb_mode.currentText()
         self._send_reports(reports, f"RGB Custom: #{r:02x}{g:02x}{b:02x} {mode_name} {brightness}%")
@@ -2405,7 +2553,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return self._apply_polling_holtek(rate)
 
         payload = vp.POLLING_RATE_PAYLOADS[rate]
-        reports = [vp.build_simple(0x04), vp.build_simple(0x03), vp.build_report(0x07, payload)]
+        reports = [vp.build_simple(vp.CMD_READY), vp.build_report(vp.CMD_WRITE, payload)]
         self._send_reports(reports, f"Polling {rate} Hz")
 
     def _sync_dpi_presets(self) -> None:
@@ -2428,13 +2576,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.device_type == 'holtek':
             return self._apply_dpi_holtek()
 
-        reports = [vp.build_simple(0x03)]
+        reports = [vp.build_simple(vp.CMD_READY)]
         for slot, (_, _, value_spin, tweak_spin) in enumerate(self.dpi_rows):
             value = value_spin.value()
             tweak = vp.dpi_value_to_tweak(value)
             tweak_spin.setValue(tweak)
             reports.append(vp.build_dpi(slot, value, tweak))
-        # reports.append(vp.build_simple(0x04)) # No trailing 0x04
         self._send_reports(reports, "DPI slots")
 
     def _on_dpi_spin_changed(self, row_index: int) -> None:
@@ -2663,18 +2810,19 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
-            self._send_reports([vp.build_simple(0x09)], "Factory reset")
-            QtWidgets.QMessageBox.information(self, "Reset Complete", "Factory reset command sent.")
+            if self._send_reports(
+                    [vp.build_simple(vp.CMD_FACTORY_RESET)], "Factory reset"):
+                QtWidgets.QMessageBox.information(
+                    self, "Reset Complete", "Factory reset command acknowledged.")
 
     def _reclaim_device(self) -> None:
         """Attempt to reclaim all Venus devices from other processes."""
         self._log("USB: Attempting to reclaim Venus devices from other processes...")
         found = False
-        for vid in vp.VENDOR_IDS:
-            for pid in vp.PRODUCT_IDS:
-                if vp.reclaim_device(vid, pid):
-                    self._log(f"USB: Reclaim attempt sent to {vid:04X}:{pid:04X}")
-                    found = True
+        for vid, pid in sorted(vp.SUPPORTED_DEVICE_IDS):
+            if vp.reclaim_device(vid, pid):
+                self._log(f"USB: Reclaim attempt sent to {vid:04X}:{pid:04X}")
+                found = True
         
         if found:
             self._log("USB: Reclaim sequence complete. Refreshing...")
@@ -2684,12 +2832,12 @@ class MainWindow(QtWidgets.QMainWindow):
             self._log("USB: No devices found to reclaim.")
             QtWidgets.QMessageBox.information(self, "Device Reclaim", "No Venus Pro devices found on the USB bus.")
 
-    def _read_settings(self) -> None:
-        if not self._require_device(auto_mode=True):
+    def _read_settings(self, silent: bool = False) -> None:
+        if not self._require_device(auto_mode=silent):
             return
 
         if self.device_type == 'holtek':
-            return self._read_settings_holtek()
+            return self._read_settings_holtek(silent=silent)
 
         self._log("--- Reading from Device ---")
         device = None
@@ -2702,11 +2850,8 @@ class MainWindow(QtWidgets.QMainWindow):
             max_retries = 3
             for attempt in range(max_retries):
                 try:
-                    # Enter read mode with handshake only (Windows sends 0x03 to start reads)
-                    device.send(vp.build_simple(0x03))
-                    
-                    # Try reading Page 0 to verify connection
-                    device.read_flash(0, 0, 8)
+                    if not device.start_session():
+                        raise vp.ProtocolError("startup challenge was rejected")
                     break # Success
                 except Exception as e:
                     if attempt < max_retries - 1:
@@ -2719,23 +2864,24 @@ class MainWindow(QtWidgets.QMainWindow):
                     else:
                         raise e
             
-            # Page 0 contains most settings
+            # The vendor utility reads the 0x0000..0x009f configuration block.
             page0 = bytearray()
-            # Read in larger chunks if reliable, but sticking to 8 bytes for now
-            for offset in range(0, 256, 8):
-                chunk = device.read_flash(0, offset, 8)
+            for offset in range(0, 0xA0, 10):
+                chunk = device.read_flash(0, offset, 10)
                 page0.extend(chunk)
             
             # Page 1 contains keyboard mappings (Part 1)
             page1 = bytearray()
-            for offset in range(0, 256, 8):
-                chunk = device.read_flash(1, offset, 8)
+            for offset in range(0, 256, 10):
+                length = min(10, 256 - offset)
+                chunk = device.read_flash(1, offset, length)
                 page1.extend(chunk)
 
             # Page 2 contains keyboard mappings (Part 2)
             page2 = bytearray()
-            for offset in range(0, 256, 8):
-                chunk = device.read_flash(2, offset, 8)
+            for offset in range(0, 256, 10):
+                length = min(10, 256 - offset)
+                chunk = device.read_flash(2, offset, length)
                 page2.extend(chunk)
 
 
@@ -2755,15 +2901,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 if i < len(self.dpi_rows):
                     combo, dpi_spin, value_spin, tweak_spin = self.dpi_rows[i]
                     combo.blockSignals(True)
-                    # Find DPI in combo
-                    found = False
-                    for idx in range(combo.count()):
-                        if combo.itemData(idx) == closest_dpi:
-                            combo.setCurrentIndex(idx)
-                            found = True
-                            break
-                    if not found:
-                        combo.setCurrentIndex(0) # Custom
+                    # Do not label an arbitrary raw value as a factory preset.
+                    exact_preset = vp.DPI_PRESETS.get(closest_dpi, {}).get("value") == val
+                    if exact_preset:
+                        for idx in range(combo.count()):
+                            if combo.itemData(idx) == closest_dpi:
+                                combo.setCurrentIndex(idx)
+                                break
+                    else:
+                        combo.setCurrentIndex(0)  # Custom
                     
                     dpi_spin.blockSignals(True)
                     value_spin.blockSignals(True)
@@ -2778,50 +2924,36 @@ class MainWindow(QtWidgets.QMainWindow):
                     combo.blockSignals(False)
 
             # 2. Polling Rate
-            poll_code = page0[0x04]
-            rate = 1000
-            if poll_code == 0x04: rate = 125
-            elif poll_code == 0x02: rate = 250
-            elif poll_code == 0x01: rate = 500
-            elif poll_code == 0x00: rate = 1000
+            poll_code = page0[0x00]
+            rate = vp.POLLING_CODE_TO_RATE.get(poll_code)
             
             # Find the rate in the combo box
             for i in range(self.polling_select.count()):
-                if self.polling_select.itemData(i) == rate:
+                if rate is not None and self.polling_select.itemData(i) == rate:
                     self.polling_select.setCurrentIndex(i)
                     self._log(f"  Polling Rate: {rate}Hz")
                     break
 
             # 3. RGB Settings
-            rgb_r = page0[0x55]
-            rgb_g = page0[0x56]
-            rgb_b = page0[0x57]
+            rgb_r = page0[0x54]
+            rgb_g = page0[0x55]
+            rgb_b = page0[0x56]
             rgb_mode = page0[0x58]
-            brightness_b1 = page0[0x5B]
-            
-            self.rgb_current_color = QtGui.QColor(rgb_r, rgb_g, rgb_b)
-            self.rgb_color_button.setStyleSheet(
-                f"background-color: {self.rgb_current_color.name()}; "
-                f"color: {'white' if self.rgb_current_color.lightness() < 128 else 'black'}; "
-                f"font-weight: bold;"
-            )
-            
-            # Update mode combo
-            # Map 0x56/0x57 back to our labels
-            if rgb_mode == 0x56:
-                idx = self.rgb_mode.findData(vp.RGB_MODE_STEADY)
-                if idx >= 0: self.rgb_mode.setCurrentIndex(idx)
-            elif rgb_mode == 0x57:
-                idx = self.rgb_mode.findData(vp.RGB_MODE_BREATHING) # Or neon
-                if idx >= 0: self.rgb_mode.setCurrentIndex(idx)
-            elif rgb_mode == 0x00: # Off
-                idx = self.rgb_mode.findData(vp.RGB_MODE_OFF)
-                if idx >= 0: self.rgb_mode.setCurrentIndex(idx)
-            
-            # Brightness
-            brightness = int(brightness_b1 / 3)
-            self.rgb_brightness.setValue(brightness)
-            self.rgb_brightness_label.setText(f"{brightness}%")
+            brightness_b1 = page0[0x5A]
+            brightness = (100 if brightness_b1 == 0xFF else
+                          0 if brightness_b1 <= 1 else
+                          min(100, round(brightness_b1 / 3)))
+
+            # While battery mode owns the hardware LED, retain the saved
+            # manual lighting in the controls so disabling can restore it.
+            if self.battery_led_enabled and self._battery_led_restore:
+                self._apply_rgb_restore_to_widgets(self._battery_led_restore)
+            else:
+                self._set_custom_color(QtGui.QColor(rgb_r, rgb_g, rgb_b))
+                mode_index = self.rgb_mode.findData(rgb_mode)
+                if mode_index >= 0:
+                    self.rgb_mode.setCurrentIndex(mode_index)
+                self.rgb_brightness.setValue(brightness)
             self._log(f"  RGB: ({rgb_r},{rgb_g},{rgb_b}), Mode: 0x{rgb_mode:02X}, Brightness: {brightness}%")
 
             # 4. Button Bindings
@@ -2838,84 +2970,43 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._log(f"DEBUG: Parsing {button_key} (Offset 0x{offset:02X}) -> Type 0x{btype:02X}, D1 0x{d1:02X}, D2 0x{d2:02X}")
 
                 if btype == vp.BUTTON_TYPE_MOUSE:
-                    if d1 == 0x01: action = "Left Click"
-                    elif d1 == 0x02: action = "Right Click"
-                    elif d1 == 0x04: action = "Middle Click"
-                    elif d1 == 0x08: action = "Back"
-                    elif d1 == 0x10: action = "Forward"
-                    else: action = f"Mouse Button (0x{d1:02X})"
-                
-                # Correct parsing maps back to dict for consistent params
-                params = {}
-                if action in ["Left Click", "Right Click", "Middle Click", "Back", "Forward"]:
-                    params["type"] = "mouse" # just context
-                
-                # Split logic: Type 0x05 is Standard Keyboard, Type 0x02 is DPI Legacy
-                elif btype == vp.BUTTON_TYPE_KEYBOARD: # 0x05 (Standard/Complex)
-                    p1_offset = profile.code_lo
-                    # ... (rest of keyboard logic follows)
-                    
-                elif btype == vp.BUTTON_TYPE_DPI_LEGACY: # 0x02 (DPI Shortcuts)
-                    action = "DPI Control"
-                    # D1 determines function: 02=Loop, 03=+, 01=-
-                    params["dpi_func"] = d1
-                    
-                # Continue with old logic for compat if needed, but the elif above handles 0x05
-                if btype == vp.BUTTON_TYPE_KEYBOARD: # Re-enter block for keyboard processing
-                    p1_offset = profile.code_lo
-                    # Use code_hi to determine which page to read from
-                    kbd_page_src = page1 if profile.code_hi == 0x01 else page2
-                    page_name = "Page 1" if profile.code_hi == 0x01 else "Page 2"
-                    
-                    self._log(f"  DEBUG: Checking {page_name} offset 0x{p1_offset:02X}")
-                    
-                    kbd_page = kbd_page_src # Alias
-                    
-                    # Ensure offset is within bounds (256 bytes per page)
-                    if p1_offset + 8 <= len(kbd_page):
-                        # Dump raw bytes for debugging
-                        raw_bytes = kbd_page[p1_offset : p1_offset + 8]
-                        self._log(f"  DEBUG: Raw Kbd Data: {raw_bytes.hex()}")
-
-                        # Flash format seems to be: [Type] [Header] [Key] [Mod] ... without the 0x08 length byte
-                        p1_type = kbd_page[p1_offset + 0]
-                        p1_header = kbd_page[p1_offset + 1]
-                        
-                     
-                        if p1_type == 0x02:
-                            # Standard Key or Media
-                            if p1_header == 0x81: # Keyboard
-                                action = "Keyboard Key"
-                                params["key"] = kbd_page[p1_offset + 2]
-                                # Modifier is in Page 0 D1 field, NOT Page 1/2 data
-                                params["mod"] = d1
-                            elif p1_header == 0x82: # Media
-                                action = "Media Key"
-                                params["key"] = kbd_page[p1_offset + 2]
-                            else:
-                                action = f"Unknown Kbd (02 {p1_header:02X})"
-                        elif p1_type == 0x04:
-                            # Complex binding (4-event stream with modifiers)
-                            # Format: [04] [80 MM 00] [81 KK 00] [40 MM 00] [41 KK 00] [Guard]
-                            # Byte offsets: 0=count, 1=80(ModDn), 2=Modifier, 3=pad, 4=81(KeyDn), 5=Key, 6=pad
-                            action = "Keyboard Key"
-                            params["key"] = kbd_page[p1_offset + 5]  # Key is at offset+5 (after 81)
-                            # For 4-event stream, modifier is embedded in the ModDn event (byte 2)
-                            params["mod"] = kbd_page[p1_offset + 2]  # Modifier from ModDn event
-                        elif p1_type == 0x06:
-                            # Multi-modifier binding (6-event stream: Ctrl+Shift+Key)
-                            # Format: [06] [80 M1 00] [80 M2 00] [81 KK 00] [40 M1 00] [40 M2 00] [41 KK 00]
-                            # Byte offsets: 0=count, 1-3=ModDn1, 4-6=ModDn2, 7=81(KeyDn), 8=Key
-                            action = "Keyboard Key"
-                            params["key"] = kbd_page[p1_offset + 8]  # Key is at offset+8 (after two ModDn + 81)
-                            # Combine both modifiers (OR them together)
-                            mod1 = kbd_page[p1_offset + 2]  # First modifier
-                            mod2 = kbd_page[p1_offset + 5]  # Second modifier
-                            params["mod"] = mod1 | mod2
-                        else:
-                            action = f"Unknown Type (0x{p1_type:02X})"
+                    action = {
+                        0x01: "Left Click", 0x02: "Right Click",
+                        0x04: "Middle Click", 0x08: "Back", 0x10: "Forward",
+                    }.get(d1, f"Mouse Button (0x{d1:02X})")
+                elif btype == vp.BUTTON_TYPE_KEYBOARD:
+                    definition_page = page1 if profile.code_hi == 0x01 else page2
+                    block = bytes(definition_page[profile.code_lo:profile.code_lo + 0x20])
+                    count = block[0] if block else 0
+                    needed = 1 + count * 3 + 1
+                    if count == 0 or needed > len(block):
+                        action = "Invalid Key Definition"
                     else:
-                        action = "Disabled (OOB)"
+                        if sum(block[:needed]) & 0xFF != 0x55:
+                            self._log(f"  Warning: {button_key} key definition checksum is invalid")
+                        modifiers = 0
+                        keycode = None
+                        consumer_usage = None
+                        for event_index in range(count):
+                            start = 1 + event_index * 3
+                            status, code_lo, code_hi = block[start:start + 3]
+                            if status == 0x80:
+                                modifiers |= code_lo
+                            elif status == 0x81 and keycode is None:
+                                keycode = code_lo
+                            elif status == 0x82 and consumer_usage is None:
+                                consumer_usage = code_lo | (code_hi << 8)
+                        if consumer_usage is not None:
+                            action = "Media Key"
+                            params = {"code": consumer_usage}
+                        elif keycode is not None:
+                            action = "Keyboard Key"
+                            params = {"key": keycode, "mod": modifiers}
+                        else:
+                            action = "Unknown Key Definition"
+                elif btype == vp.BUTTON_TYPE_DPI_LEGACY:
+                    action = "DPI Control"
+                    params = {"func": d1}
                 elif btype == vp.BUTTON_TYPE_MACRO:
                     action = "Macro"
                     macro_index = d1
@@ -2929,17 +3020,8 @@ class MainWindow(QtWidgets.QMainWindow):
                     else:
                         params["count"] = 1 # Default for other modes
                     
-                    # Fetch macro name from its flash page
-                    m_page, m_offset = vp.get_macro_slot_info(d1)
-                    try:
-                        name_chunk = device.read_flash(m_page, m_offset, 8)
-                        if name_chunk and name_chunk[0] > 0 and name_chunk[0] <= 22:
-                            nlen = name_chunk[0]
-                            params["name"] = name_chunk[1:1+nlen].decode('utf-16le', errors='ignore')
-                        else:
-                            params["name"] = f"Macro {macro_index+1}"
-                    except:
-                        params["name"] = f"Macro {macro_index+1}"
+                    params["name"] = self.macro_names.get(
+                        macro_index + 1, f"Macro {macro_index + 1}")
                 elif btype == vp.BUTTON_TYPE_SPECIAL:
                     action = "Triple Click" if d1 == 50 else "Fire Key"
                     params["delay"] = d1
@@ -2962,11 +3044,19 @@ class MainWindow(QtWidgets.QMainWindow):
             # Sending 0x04/0x03 here would RE-ENTER config mode and break button inputs!
             
             self._log("--- Done Reading ---")
-            QtWidgets.QMessageBox.information(self, "Read Success", "Configuration successfully read from device.")
+            self.status_label.setText("Status: Ready — configuration read")
+            self.status_label.setStyleSheet("")
+            if not silent:
+                QtWidgets.QMessageBox.information(
+                    self, "Read Success",
+                    "Configuration successfully read from device.")
 
         except Exception as e:
             self._log(f"Error reading configuration: {e}")
-            QtWidgets.QMessageBox.critical(self, "Read Error", str(e))
+            self.status_label.setText("Status: Read failed — see log")
+            self.status_label.setStyleSheet("color: orange; font-weight: bold;")
+            if not silent:
+                QtWidgets.QMessageBox.critical(self, "Read Error", str(e))
         finally:
             # Always close the device
             if device:
@@ -3056,7 +3146,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
         except Exception as e:
             self._log(f"Error reading Holtek configuration: {e}")
-            QtWidgets.QMessageBox.critical(self, "Read Error", str(e))
+            self.status_label.setText("Status: Read failed — see log")
+            self.status_label.setStyleSheet("color: orange; font-weight: bold;")
+            if not silent:
+                QtWidgets.QMessageBox.critical(self, "Read Error", str(e))
         finally:
             if device:
                 device.close()
@@ -3079,25 +3172,37 @@ class MainWindow(QtWidgets.QMainWindow):
         progress.show()
         
         device = None
+        cancelled = False
         try:
             # Open device transiently
             device = vp.VenusDevice(self.device_path)
             device.open()
+            if not device.start_session():
+                raise vp.ProtocolError("startup challenge was rejected")
             
             with open(fname, "wb") as f:
                 for page in range(256):
                     if progress.wasCanceled():
+                        cancelled = True
                         break
                     progress.setValue(page)
                     
                     # Read page (256 bytes)
                     page_data = bytearray()
-                    for offset in range(0, 256, 8):
-                        chunk = device.read_flash(page, offset, 8)
+                    for offset in range(0, 256, 10):
+                        length = min(10, 256 - offset)
+                        chunk = device.read_flash(page, offset, length)
                         page_data.extend(chunk)
                     f.write(page_data)
-            self._log(f"Profile exported to {fname}")
-            QtWidgets.QMessageBox.information(self, "Export Successful", f"Profile saved to {fname}")
+            if cancelled:
+                self._log(f"Profile export canceled; partial dump remains at {fname}")
+                QtWidgets.QMessageBox.information(
+                    self, "Export Canceled", f"A partial dump remains at {fname}")
+            else:
+                progress.setValue(256)
+                self._log(f"Profile exported to {fname}")
+                QtWidgets.QMessageBox.information(
+                    self, "Export Successful", f"Profile saved to {fname}")
         except Exception as e:
             self._log(f"Export failed: {e}")
             QtWidgets.QMessageBox.critical(self, "Export Failed", str(e))
@@ -3120,7 +3225,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
             
         try:
-            data = open(fname, "rb").read()
+            data = Path(fname).read_bytes()
             if len(data) != 65536: # 256 * 256
                 QtWidgets.QMessageBox.warning(self, "Invalid File", f"File size must be exactly 64KB (got {len(data)} bytes).")
                 return
@@ -3142,19 +3247,20 @@ class MainWindow(QtWidgets.QMainWindow):
         progress.show()
         
         device = None
+        imported = False
+        cancelled = False
         try:
             # Open device transiently
             device = vp.VenusDevice(self.device_path)
             device.open()
-            
-            # Send initial prepare
-            device.send(vp.build_simple(0x03))
-            device.send(vp.build_simple(0x03))
-            
-            import time
+            if not device.start_session():
+                raise vp.ProtocolError("startup challenge was rejected")
+            if not device.begin_write():
+                raise RuntimeError(device.last_error or "Mouse did not enter ready state")
             
             for page in range(256):
                 if progress.wasCanceled():
+                    cancelled = True
                     break
                 progress.setValue(page)
                 
@@ -3164,17 +3270,29 @@ class MainWindow(QtWidgets.QMainWindow):
                 
                 # Write in 10-byte chunks (protocol limit)
                 for offset in range(0, 256, 10):
+                    if progress.wasCanceled():
+                        cancelled = True
+                        break
                     chunk = page_data[offset : offset + 10]
                     packet = vp.build_flash_write(page, offset, chunk)
-                    device.send(packet)
-                    time.sleep(0.002)
-                    
-            # Finalize
-            device.send(vp.build_simple(0x04))
-            device.send(vp.build_simple(0x04))
-            
-            self._log(f"Profile imported from {fname}")
-            QtWidgets.QMessageBox.information(self, "Import Successful", "Profile successfully written to device.")
+                    if not device.send_reliable(packet):
+                        raise RuntimeError(
+                            device.last_error or
+                            f"Write failed at 0x{page:02x}{offset:02x}")
+                if cancelled:
+                    break
+
+            if cancelled:
+                self._log("Profile import canceled; the device contains a partial write")
+                QtWidgets.QMessageBox.warning(
+                    self, "Import Canceled",
+                    "Import stopped after a partial write. Re-import a complete profile before relying on the device configuration.")
+            else:
+                imported = True
+                progress.setValue(256)
+                self._log(f"Profile imported from {fname}")
+                QtWidgets.QMessageBox.information(
+                    self, "Import Successful", "Profile successfully written to device.")
             
         except Exception as e:
             self._log(f"Import failed: {e}")
@@ -3184,8 +3302,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 device.close()
             progress.close()
         
-        # Reload settings (after device is closed)
-        self._read_settings()
+        # Reload settings only after a complete import (and after closing HID).
+        if imported:
+            self._read_settings()
 
     def _initialize_default_assignments(self) -> None:
         """Initialize assignments with Disabled for all known buttons."""
@@ -3234,38 +3353,26 @@ class MainWindow(QtWidgets.QMainWindow):
             # Open device transiently
             device = vp.VenusDevice(self.device_path)
             device.open()
-            
-            # Read two pages of macro data
-            for off in range(0, 256, 8):
-                data.extend(device.read_flash(start_page, off, 8))
-            for off in range(0, 256, 8):
-                data.extend(device.read_flash(start_page + 1, off, 8))
-            
-            # Slice relevant part
-            if start_offset == 0:
-                raw_macro = data[0:384]
-            else:
-                raw_macro = data[128 : 128 + 384]
+            if not device.start_session():
+                raise vp.ProtocolError("startup challenge was rejected")
+
+            # Read exactly one 0x180-byte slot from its absolute address.
+            slot_address = (start_page << 8) | start_offset
+            for relative in range(0, 0x180, vp.MAX_DATA_LEN):
+                address = slot_address + relative
+                length = min(vp.MAX_DATA_LEN, 0x180 - relative)
+                data.extend(device.read_flash(
+                    (address >> 8) & 0xFF, address & 0xFF, length))
+            raw_macro = bytes(data)
                 
             # Parse Name
-            slot_in_data = raw_macro[0]
-            self._log(f"  Slot index in data: {slot_in_data}")
-            
-            # Find name by looking for null terminator in UTF-16LE
-            name_bytes = bytearray()
-            for i in range(1, 29, 2):
-                if i+1 < len(raw_macro):
-                    lo = raw_macro[i]
-                    hi = raw_macro[i+1]
-                    if lo == 0 and hi == 0:
-                        break
-                    name_bytes.extend([lo, hi])
-            
-            if name_bytes:
+            name_length = raw_macro[0]
+            self._log(f"  Name length: {name_length} bytes")
+            if 0 < name_length <= 30 and name_length % 2 == 0:
                 try:
-                    name = name_bytes.decode('utf-16le')
+                    name = raw_macro[1:1 + name_length].decode('utf-16le')
                     self.macro_name_edit.setText(name)
-                except:
+                except UnicodeDecodeError:
                     self.macro_name_edit.setText(f"Macro {slot_index}")
             else:
                 self.macro_name_edit.setText(f"Macro {slot_index}")
@@ -3273,25 +3380,49 @@ class MainWindow(QtWidgets.QMainWindow):
             # Parse Events
             self.macro_event_table.setRowCount(0)
             event_offset = 0x20
-            
-            while event_offset < 380:
+            event_count = raw_macro[0x1F]
+            if event_count > vp.MACRO_MAX_EVENTS:
+                raise vp.ProtocolError(
+                    f"macro slot reports impossible event count {event_count}")
+            events_end = event_offset + event_count * 5
+            expected_checksum = vp.calculate_terminator_checksum(
+                raw_macro, event_count)
+            if raw_macro[events_end] != expected_checksum:
+                self._log(
+                    f"  Warning: macro checksum is invalid "
+                    f"(stored {raw_macro[events_end]:02x}, expected {expected_checksum:02x})")
+            mouse_names = {
+                0x01: "Mouse: Left Button",
+                0x02: "Mouse: Right Button",
+                0x04: "Mouse: Middle Button",
+                0x08: "Mouse: Back Button",
+                0x10: "Mouse: Forward Button",
+            }
+
+            for _ in range(event_count):
                 if event_offset + 5 > 384:
                     break
                     
                 b0 = raw_macro[event_offset]
                 b1 = raw_macro[event_offset+1]
                 
-                if b0 not in (0x81, 0x41, 0x80, 0x40):
+                if b0 not in (0x81, 0x41, 0x80, 0x40, 0x84, 0x44):
                     break
                     
                 keycode = b1
                 delay = (raw_macro[event_offset+3] << 8) | raw_macro[event_offset+4]
-                is_down = (b0 == 0x81 or b0 == 0x80)
+                is_down = bool(b0 & 0x80)
                 is_modifier = (b0 == 0x80 or b0 == 0x40)
-                
-                key_name = self.HID_USAGE_TO_NAME.get(keycode, f"Key 0x{keycode:02X}")
-                
-                self._add_event_to_table(key_name, is_down, delay, is_modifier)
+                is_mouse = (b0 & 0x07) == 0x04
+
+                if is_mouse:
+                    key_name = mouse_names.get(keycode, f"Mouse: Button 0x{keycode:02X}")
+                    self._add_event_to_table(key_name, is_down, delay,
+                                             event_type="mouse", keycode=keycode)
+                else:
+                    key_name = self.HID_USAGE_TO_NAME.get(keycode, f"Key 0x{keycode:02X}")
+                    self._add_event_to_table(key_name, is_down, delay, is_modifier,
+                                             keycode=keycode)
                 
                 event_offset += 5
                 

--- a/venus_protocol.py
+++ b/venus_protocol.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Optional
-
-import hid
-import time
+import secrets
 import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+try:
+    import hid
+    HIDAPI_AVAILABLE = True
+except ImportError:
+    hid = None
+    HIDAPI_AVAILABLE = False
 
 try:
     import usb.core
@@ -24,10 +31,11 @@ def reclaim_device(vendor_id: int, product_id: int) -> bool:
         return False
         
     try:
-        # For each interface, try to re-attach
+        # For each interface through the vendor configuration interface, try
+        # to re-attach.  Holtek uses interface 2, while Areson uses 1.
         # This will fail if another process has a persistent LOCK, 
         # but can break simple captures.
-        for iface in [0, 1]:
+        for iface in range(expected_interface(vendor_id, product_id) + 1):
             try:
                 # First, try to detach if a non-kernel driver is active
                 # (PyUSB doesn't tell us WHO has it, just if it's kernel or not)
@@ -68,7 +76,7 @@ def is_device_busy(vendor_id: int, product_id: int) -> bool:
     # If not active, and hidapi didn't see it, it's likely captured via usbfs
     try:
         busy = False
-        for iface in [0, 1]:
+        for iface in range(expected_interface(vendor_id, product_id) + 1):
             if not dev.is_kernel_driver_active(iface):
                 busy = True
                 break
@@ -77,81 +85,24 @@ def is_device_busy(vendor_id: int, product_id: int) -> bool:
         return True # Assume busy if we can't even check
 
 def try_unlock_device() -> bool:
-    """Attempts to unlock the device by sending magic packets via pyusb.
-    
-    This is required if the device is in a weird state or not accepting commands.
+    """Deprecated compatibility shim.
+
+    Captures and the vendor binary contain no ``0x4d`` unlock command.  Older
+    versions also put the destructive ``0x09`` factory-reset command in an
+    "unlock" path.  Session setup now belongs to :meth:`VenusDevice.start_session`
+    and requires an already-selected config-interface path.
     """
-    if not PYUSB_AVAILABLE:
-        print("Unlock: python-pyusb not installed.")
-        return False
-
-    print("Attempting to unlock device...")
-    dev = None
-    for vid in VENDOR_IDS:
-        for pid in PRODUCT_IDS:
-            dev = usb.core.find(idVendor=vid, idProduct=pid)
-            if dev is not None:
-                break
-        if dev is not None:
-            break
-    
-    if dev is None:
-        print("Unlock: No device found.")
-        return False
-
-    # Detach Kernel Driver
-    reattach = []
-    for iface in [0, 1]:
-        if dev.is_kernel_driver_active(iface):
-            try:
-                dev.detach_kernel_driver(iface)
-                reattach.append(iface)
-                print(f"Detached kernel driver from iface {iface}")
-            except Exception as e:
-                print(f"Failed to detach iface {iface}: {e}")
-                return False
-
-    try:
-        usb.util.claim_interface(dev, 1)
-        
-        # Helper to send feature report to Interface 1
-        def send_magic(data):
-            padded = data.ljust(17, b'\x00')
-            dev.ctrl_transfer(0x21, 0x09, 0x0308, 1, padded)
-
-        # 1. SKIP Reset (Cmd 09) - Causes instability/re-enumeration issues
-        # send_magic(bytes([0x08, 0x09]))
-        # time.sleep(0.5)
-        
-        # 2. Magic packet 1 (CMD 4D)
-        # 08 4D 05 50 00 55 00 55 00 55 91
-        send_magic(bytes([0x08, 0x4D, 0x05, 0x50, 0x00, 0x55, 0x00, 0x55, 0x00, 0x55, 0x91]))
-        time.sleep(0.05)
-        
-        # 3. Magic packet 2 (CMD 01)
-        # 08 01 00 00 00 04 56 57 3d 1b 00 00
-        send_magic(bytes([0x08, 0x01, 0x00, 0x00, 0x00, 0x04, 0x56, 0x57, 0x3d, 0x1b, 0x00, 0x00]))
-        time.sleep(0.05)
-        
-        print("Unlock sequence sent.")
-        
-    except Exception as e:
-        print(f"Unlock error: {e}")
-    finally:
-        # Re-attach Check
-        for iface in reattach:
-            try:
-                dev.attach_kernel_driver(iface)
-                print(f"Re-attached kernel driver to iface {iface}")
-            except:
-                pass
-        # Wait for device to re-enumerate after driver re-attach
-        time.sleep(1.0)
-    return True
+    print("Unlock is obsolete; reconnect and use VenusDevice.start_session().", file=sys.stderr)
+    return False
 
 
-VENDOR_IDS = (0x25A7, 0x04D9)
-PRODUCT_IDS = (0xFA07, 0xFA08, 0xFC55)
+SUPPORTED_DEVICE_IDS = {
+    (0x25A7, 0xFA07),  # Areson/Compx wireless receiver
+    (0x25A7, 0xFA08),  # Areson/Compx wired connection
+    (0x04D9, 0xFC55),  # Holtek wired variant (different protocol)
+}
+VENDOR_IDS = tuple(sorted({vid for vid, _ in SUPPORTED_DEVICE_IDS}))
+PRODUCT_IDS = tuple(sorted({pid for _, pid in SUPPORTED_DEVICE_IDS}))
 # Map for friendly names
 DEVICE_NAMES = {
     (0x25A7, 0xFA07): "Venus Pro (Wireless)",
@@ -160,8 +111,18 @@ DEVICE_NAMES = {
 }
 
 REPORT_ID = 0x08
+RESPONSE_REPORT_ID = 0x09
 REPORT_LEN = 17
 CHECKSUM_BASE = 0x55
+MAX_DATA_LEN = 10
+
+CMD_CHALLENGE = 0x01
+CMD_NOTIFY = 0x02
+CMD_READY = 0x03
+CMD_STATUS = 0x04
+CMD_WRITE = 0x07
+CMD_READ = 0x08
+CMD_FACTORY_RESET = 0x09
 
 
 @dataclass(frozen=True)
@@ -266,14 +227,11 @@ RGB_QUICK_PICKS = [
 
 
 
+POLLING_RATE_CODES = {125: 0x08, 250: 0x04, 500: 0x02, 1000: 0x01}
+POLLING_CODE_TO_RATE = {code: rate for rate, code in POLLING_RATE_CODES.items()}
 POLLING_RATE_PAYLOADS = {
-    # Polling rate encoding: code = log2(1000/rate)
-    # From wired USB captures:
-    # 125Hz = code 0x04 (but pattern suggests 0x03?), 250Hz = 0x02, 500Hz = 0x01, 1000Hz = 0x00
-    125: bytes([0x00, 0x00, 0x00, 0x02, 0x04, 0x51, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-    250: bytes([0x00, 0x00, 0x00, 0x02, 0x02, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-    500: bytes([0x00, 0x00, 0x00, 0x02, 0x01, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-    1000: bytes([0x00, 0x00, 0x00, 0x02, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    rate: bytes([0x00, 0x00, 0x00, 0x02, code, (0x55 - code) & 0xFF]) + bytes(8)
+    for rate, code in POLLING_RATE_CODES.items()
 }
 
 
@@ -423,6 +381,7 @@ RGB_MODE_OFF = 0x00
 RGB_MODE_STEADY = 0x01
 RGB_MODE_NEON = 0x02
 RGB_MODE_BREATHING = 0x03  # Uses different packet format (offset 0x5C)
+RGB_MIN_BRIGHTNESS = 0  # build_rgb encodes this as the captured raw minimum 0x01
 
 # ASCII to HID mapping for Quick Text Macro
 # Maps char -> (keycode, modifier_mask)
@@ -456,6 +415,12 @@ MACRO_REPEAT_COUNT = 0x02    # Multi-repeat mode (GUI sentinel)
 MACRO_REPEAT_HOLD = 0xFE     # Repeat while button held
 MACRO_REPEAT_TOGGLE = 0xFF   # Toggle on/off
 # Note: Any value 0x01-0xFD is interpreted as a repeat count.
+MACRO_SLOT_SIZE = 0x180
+MACRO_HEADER_SIZE = 0x20
+MACRO_TERMINATOR_SIZE = 4
+MACRO_MAX_EVENTS = (
+    MACRO_SLOT_SIZE - MACRO_HEADER_SIZE - MACRO_TERMINATOR_SIZE
+) // 5
 
 
 # Mapping of Side Buttons (1-12) to internal Macro Slot Indices
@@ -473,15 +438,21 @@ def calc_checksum(prefix: Iterable[int]) -> int:
 
 
 def build_report(command: int, payload: Iterable[int]) -> bytes:
-    """Builds a 17-byte HID report with checksum at byte 16."""
+    """Build one 17-byte request feature report.
+
+    Byte 2 is reserved and is part of the command payload.  EEPROM commands
+    use bytes 3..4 as one big-endian 16-bit address; referring to them as a
+    profile and offset obscured the fact that this model has one profile.
+    """
     r = bytearray(REPORT_LEN)
     r[0] = REPORT_ID
-    r[1] = command
+    r[1] = command & 0xFF
     
     # Payload
     payload_bytes = bytes(payload)
-    plen = min(len(payload_bytes), 14)
-    r[2:2+plen] = payload_bytes[:plen]
+    if len(payload_bytes) > 14:
+        raise ValueError("report payload must be at most 14 bytes")
+    r[2:2 + len(payload_bytes)] = payload_bytes
     
     # Packet Checksum
     s_sum = sum(r[0:16]) & 0xFF
@@ -492,29 +463,73 @@ def build_simple(command: int) -> bytes:
     return build_report(command, bytes(14))
 
 
+def report_checksum_valid(report: Iterable[int]) -> bool:
+    raw = bytes(report)
+    return len(raw) == REPORT_LEN and (sum(raw) & 0xFF) == CHECKSUM_BASE
+
+
+def build_memory_write(address: int, data: bytes) -> bytes:
+    """Build an EEPROM write for an absolute 16-bit address."""
+    if not 0 <= address <= 0xFFFF:
+        raise ValueError("address must be 0x0000..0xffff")
+    if not 1 <= len(data) <= MAX_DATA_LEN:
+        raise ValueError(f"write data must contain 1..{MAX_DATA_LEN} bytes")
+    payload = bytes([
+        0x00,
+        (address >> 8) & 0xFF,
+        address & 0xFF,
+        len(data),
+    ]) + data.ljust(MAX_DATA_LEN, b"\x00")
+    return build_report(CMD_WRITE, payload)
+
+
 def build_flash_write(page: int, offset: int, data: bytes) -> bytes:
-    """Generic flash write packet (Cmd 0x07).
-    
-    Payload: [0x00, Page, Offset, Len, Data...]
-    Data is padded to 10 bytes.
-    """
-    dlen = len(data)
-    payload = bytes([0x00, page & 0xFF, offset & 0xFF, dlen & 0xFF]) + data.ljust(10, b'\x00')
-    return build_report(0x07, payload)
+    """Compatibility wrapper around :func:`build_memory_write`."""
+    return build_memory_write(((page & 0xFF) << 8) | (offset & 0xFF), data)
 
 
 def build_flash_read(page: int, offset: int, length: int) -> bytes:
-    """Build a flash memory read request.
-    
-    The response will arrive on the Interrupt In endpoint (Report ID 0x09).
-    Max reliable length per report is 10-11 bytes.
-    """
+    """Build a memory read; its response is interrupt-IN report ``0x09``."""
+    if not 1 <= length <= MAX_DATA_LEN:
+        raise ValueError(f"read length must be 1..{MAX_DATA_LEN}")
     payload = bytes([0x00, page & 0xFF, offset & 0xFF, length & 0xFF]) + bytes(10)
-    return build_report(0x08, payload)
+    return build_report(CMD_READ, payload)
 
 
-def build_key_binding(code_hi: int, code_lo: int, hid_key: int, modifier: int = 0x00) -> bytes:
-    """Build a key binding packet.
+def build_challenge(challenge: bytes) -> bytes:
+    if len(challenge) != 4:
+        raise ValueError("challenge must be exactly four bytes")
+    return build_report(CMD_CHALLENGE, bytes([0, 0, 0, 4]) + challenge + bytes(6))
+
+
+def challenge_response(challenge: bytes) -> bytes:
+    """Return the response expected by the vendor application's check."""
+    if len(challenge) != 4:
+        raise ValueError("challenge must be exactly four bytes")
+    a, b, c, d = challenge
+    return bytes(((a + b + 5) & 0xFF, (2 * b + c) & 0xFF,
+                  (3 * c + d) & 0xFF, (4 * d + a) & 0xFF))
+
+
+def build_notify_enable() -> bytes:
+    return build_report(CMD_NOTIFY, bytes([0, 0, 0, 1, 1]) + bytes(9))
+
+
+def _definition_write_packets(code_hi: int, code_lo: int, body: bytes) -> list[bytes]:
+    packets = []
+    address = ((code_hi & 0xFF) << 8) | (code_lo & 0xFF)
+    for start in range(0, len(body), MAX_DATA_LEN):
+        packets.append(build_memory_write(address + start, body[start:start + MAX_DATA_LEN]))
+    return packets
+
+
+def _definition_checksum(events: bytes, count: int) -> int:
+    return calc_checksum(bytes([count]) + events)
+
+
+def build_key_binding(code_hi: int, code_lo: int, hid_key: int,
+                      modifier: int = 0x00) -> list[bytes]:
+    """Build the event-definition writes for one keyboard binding.
     
     Args:
         code_hi: High byte of keyboard region address (page)
@@ -527,79 +542,39 @@ def build_key_binding(code_hi: int, code_lo: int, hid_key: int, modifier: int = 
     - ctrl-alt-1: 08 07 00 01 00 0a 06 80 01 00 80 04 00 81 1e [checksum]
     """
     
+    if not 0 <= hid_key <= 0xFF:
+        raise ValueError("hid_key must fit in one byte")
+    if modifier & ~0x0F:
+        raise ValueError("modifier may contain Ctrl, Shift, Alt, and Win only")
+
+    # The firmware does not accept a combined modifier mask as one event.  The
+    # Windows utility emits one event for every set bit, in this order.
+    modifier_values = [bit for bit in (MODIFIER_CTRL, MODIFIER_SHIFT,
+                                       MODIFIER_ALT, MODIFIER_WIN)
+                       if modifier & bit]
     events = bytearray()
-    
-    if modifier != 0:
-        # Complex Binding with Modifiers - FULL 4-EVENT STREAM
-        # Based on actual Windows dump analysis of Shift+A (B12):
-        # Data: 04 80 02 00 81 04 00 40 02 00 41 04 00 c3
-        # Format: [Count=4] [ModDn] [KeyDn] [ModUp] [KeyUp] [Guard]
-        
-        events.extend([0x80, modifier, 0x00])  # Event 1: ModDn
-        events.extend([0x81, hid_key, 0x00])   # Event 2: KeyDn
-        events.extend([0x40, modifier, 0x00])  # Event 3: ModUp
-        events.extend([0x41, hid_key, 0x00])   # Event 4: KeyUp
-        
-        count = 4  # Always 4 events for modifier bindings
-        full_payload = bytearray([count]) + events
-        
-        # Guard byte for complex bindings
-        # From dump: Shift+A (mod=0x02, key=0x04) -> Guard=0xC3
-        # Empirical formula: Simple guard + offset for event stream
-        simple_guard = (0x91 - (hid_key * 2)) & 0xFF
-        # The modifier events add ~0x3E offset based on analysis
-        guard = (simple_guard + 0x3A) & 0xFF
-        full_payload.append(guard)
-        
-        # Total: 1 + 12 + 1 = 14 bytes (will split into 10 + 4)
-        
-    else:
-        # Simple Binding (No Modifiers)
-        # Format: [Count=2] [KeyDn] [KeyUp] [Guard] = 8 bytes
-        events.extend([0x81, hid_key, 0x00])  # KeyDn
-        events.extend([0x41, hid_key, 0x00])  # KeyUp
-        
-        count = 2
-        full_payload = bytearray([count]) + events
-        
-        # Guard byte: 0x91 - (key * 2)
-        guard = (0x91 - (hid_key * 2)) & 0xFF
-        full_payload.append(guard)
-        
-        # Total: 1 + 6 + 1 = 8 bytes (fits in 1 packet)
-    
-    # Split payload into chunks of max 10 bytes for the 0x07 write command
-    packets = []
-    chunk_size = 10
-    total_len = len(full_payload)
-    
-    for i in range(0, total_len, chunk_size):
-        chunk = full_payload[i : i + chunk_size]
-        current_len = len(chunk)
-        
-        # Build Write Packet (Cmd 0x07)
-        # Payload: [00] [Page] [Offset+i] [Len] [Data...]
-        # Data chunk must be padded to 10 bytes to satisfy strict 14-byte payload check in build_report
-        padded_chunk = chunk.ljust(10, b'\x00')
-        
-        pkt_payload = bytes([
-            0x00,
-            code_hi,
-            code_lo + i,
-            current_len,
-        ]) + padded_chunk
-        
-        packets.append(build_report(0x07, pkt_payload))
-        
-    return packets
+    for value in modifier_values:
+        events.extend((0x80, value, 0x00))
+    events.extend((0x81, hid_key, 0x00))
+    for value in modifier_values:
+        events.extend((0x40, value, 0x00))
+    events.extend((0x41, hid_key, 0x00))
 
-def build_key_binding_apply(code_hi: int, code_lo: int, hid_key: int, modifier: int = 0x00) -> bytes:
-    """Build the second packet for key binding with modifiers.
-    
-    With Type 02 packets (which we now use exclusively), this second packet is NOT needed.
-    """
-    return b""
+    count = 2 + 2 * len(modifier_values)
+    body = bytes([count]) + bytes(events)
+    body += bytes([_definition_checksum(events, count)])
+    return _definition_write_packets(code_hi, code_lo, body)
 
+
+def build_consumer_binding(code_hi: int, code_lo: int, usage: int) -> list[bytes]:
+    """Build a two-event USB Consumer Page definition (media key)."""
+    if not 0 <= usage <= 0xFFFF:
+        raise ValueError("consumer usage must fit in 16 bits")
+    lo, hi = usage & 0xFF, (usage >> 8) & 0xFF
+    events = bytes((0x82, lo, hi, 0x42, lo, hi))
+    count = 2
+    body = bytes([count]) + events + bytes([_definition_checksum(events, count)])
+    return _definition_write_packets(code_hi, code_lo, body)
 
 def build_rgb(r: int, g: int, b: int, mode: int = RGB_MODE_STEADY, brightness: int = 100) -> bytes:
     """Build an RGB LED control packet.
@@ -612,8 +587,9 @@ def build_rgb(r: int, g: int, b: int, mode: int = RGB_MODE_STEADY, brightness: i
     Packet formats (from USB captures):
     
     Steady/Neon (offset 0x54):
-    [00, 00, 54, 08, R, G, B, ColorChk, Mode, 54, B1, B2, 00, 00]
+    [00, 00, 54, 08, R, G, B, ColorChk, Mode, ModeChk, B1, B2, 00, 00]
     - Mode: 0x01=Steady, 0x02=Neon
+    - ModeChk = (0x55 - Mode) & 0xFF
     - ColorChk = (0x55 - (R + G + B)) & 0xFF
     - B1 = brightness * 3, B2 = (0x55 - B1) & 0xFF
     
@@ -650,8 +626,10 @@ def build_rgb(r: int, g: int, b: int, mode: int = RGB_MODE_STEADY, brightness: i
         b1 = max(1, min(255, int(brightness * 3)))
         b2 = (0x55 - b1) & 0xFF
         
-        # For Neon, use mode 0x02; for Steady, use mode 0x01
+        # For Neon, use mode 0x02; for Steady, use mode 0x01.  The following
+        # byte is its 0x55 complement (0x53 for Neon, 0x54 for Steady).
         hw_mode = 0x02 if mode == RGB_MODE_NEON else 0x01
+        mode_chk = (0x55 - hw_mode) & 0xFF
         
         payload = bytes([
             0x00,
@@ -663,7 +641,7 @@ def build_rgb(r: int, g: int, b: int, mode: int = RGB_MODE_STEADY, brightness: i
             b,
             color_chk,  # Checksum for color
             hw_mode,    # Hardware mode (0x01=Steady, 0x02=Neon)
-            0x54,       # Constant
+            mode_chk,
             b1,         # Brightness value
             b2,         # Brightness complement
             0x00,
@@ -673,28 +651,40 @@ def build_rgb(r: int, g: int, b: int, mode: int = RGB_MODE_STEADY, brightness: i
     return build_report(0x07, payload)
 
 
-def build_apply_binding(apply_offset: int, action_type: int, action_code: int, action_index: int = 0x00, modifier: int = 0x00, page: int = 0x00) -> bytes:
-    # Packet structure for Page 0 (or Profile N) binding entry:
-    # [00] [Page] [Offset] [Len=04] [Type] [D1=Modifier] [D2=action_index] [D3=action_code] ...
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,
-            action_type,
-            modifier,      # D1: Modifier goes here (Shift=0x02, Ctrl=0x01, etc.)
-            action_index,  # D2
-            action_code,   # D3
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
+def battery_gradient_rgb(percent: int) -> tuple[int, int, int]:
+    """Map battery percent onto red -> yellow -> green at full saturation."""
+    level = max(0, min(100, int(percent)))
+    if level <= 50:
+        return 255, round(255 * level / 50), 0
+    return round(255 * (100 - level) / 50), 255, 0
+
+
+def build_battery_indicator_rgb(percent: int) -> bytes:
+    """Build a steady battery-color write at the capture-confirmed minimum brightness."""
+    return build_rgb(
+        *battery_gradient_rgb(percent),
+        mode=RGB_MODE_STEADY,
+        brightness=RGB_MIN_BRIGHTNESS,
     )
-    return build_report(0x07, payload)
+
+
+def build_apply_binding(apply_offset: int, action_type: int,
+                        action_code: int | None = None,
+                        action_index: int = 0x00, modifier: int = 0x00,
+                        page: int = 0x00) -> bytes:
+    """Build a four-byte button action record.
+
+    The historical argument names are retained for callers: ``modifier`` is
+    action byte d1 and ``action_index`` is d2.  d3 is always the inner
+    checksum; accepting guessed d3 values was the cause of broken click and
+    DPI bindings.  ``action_code`` is ignored except for API compatibility.
+    """
+    del action_code
+    d1 = modifier & 0xFF
+    d2 = action_index & 0xFF
+    record = bytes((action_type & 0xFF, d1, d2,
+                    calc_checksum((action_type, d1, d2))))
+    return build_memory_write(((page & 0xFF) << 8) | (apply_offset & 0xFF), record)
 
 
 def build_keyboard_bind(apply_offset: int, page: int = 0x00) -> bytes:
@@ -711,90 +701,37 @@ def build_keyboard_bind(apply_offset: int, page: int = 0x00) -> bytes:
     d2 = 0x00
     d3 = (0x55 - (btype + d1 + d2)) & 0xFF # 0x50
     
-    payload = bytes([
-        0x00,
-        page,
-        apply_offset,
-        0x04,
-        btype,
-        d1,
-        d2,
-        d3,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    ])
-    return build_report(0x07, payload)
+    return build_memory_write(((page & 0xFF) << 8) | apply_offset,
+                              bytes((btype, d1, d2, d3)))
 
 
 def build_mouse_param(apply_offset: int, val: int, page: int = 0x00) -> bytes:
-    """Build a mouse button binding (Left/Right/etc).
+    """Build a native mouse-button binding.
     
     Args:
         apply_offset: Button offset.
         val: Mouse button code (1=Left, 2=Right, 4=Middle, 8=Back, 10=Forward).
-        page: Memory page (0x00, 0x40, etc).
+        page: High address byte; the exposed Areson action table uses page 0.
         
-    Packet structure inferred from capture contexts:
-    [00] [Page] [Offset] [Len=04] [Type=01] [Val] [00] [Code] ...
-    
-    Code mapping (Val -> Code):
-    - 0x01 (Left) -> 0xF0 (Guess/Standard?) - Wait, Forward/Back used 0x44/0x4C.
-    - Let's assume Code is not critical or is derived.
-    - Actually, build_forward_back uses explicit codes.
-    - If capture for Left Click (Btn 14, Offset 0x7C) is confusing, let's look at build_forward_back logic.
-    - Forward (0x10) -> 0x44. Back (0x08) -> 0x4c.
-    - Left/Right likely follow similar pattern or are hardcoded.
-    - Standard Mouse is Type 0x01.
+    The mask values are the same as HID mouse-button bits.  The final byte is
+    simply ``0x55 - (type + mask)`` for all five supported buttons.
     """
-    # Just use the generic payload with Type 0x01.
-    # What is D3 (Action Code)?
-    # For Forward/Back it was 0x44/0x4C.
-    # For Left/Right?
-    # Let's assume generic Type 0x01 doesn't STRICTLY verify D3 or it is 0x00?
-    # Or maybe valid vals: 
-    # Left (1) -> F0?
-    # Right (2) -> F1?
-    # Middle (4) -> F2?
-    # D3 seems to be 'Index'?
-    
-    # Safest bet: Just replicate build_apply_binding functionality for Type 0x01.
-    # D1 = val. D2 = 00. D3 = ?
-    # Let's assume D3 is not strictly checked for basic buttons or is 0.
-    
-    # Wait, build_forward_back sets D3=44/4C.
-    # Maybe I should just expose build_apply_binding and let caller handle code?
-    # But venus_gui calls build_mouse_param(offset, val).
-    
-    # Let's map val to something reasonable or just 0 if unknown.
-    code = 0x00
-    if val == 0x10: code = 0x44 # Forward
-    elif val == 0x08: code = 0x4C # Back
-    elif val == 0x01: code = 0xF0 # Left (Guess)
-    elif val == 0x02: code = 0xF1 # Right (Guess)
-    elif val == 0x04: code = 0xF2 # Middle (Guess)
-        
-    return build_apply_binding(apply_offset, action_type=BUTTON_TYPE_MOUSE, action_code=code, modifier=val, page=page)
+    if val not in (0x01, 0x02, 0x04, 0x08, 0x10):
+        raise ValueError("mouse mask must be Left, Right, Middle, Back, or Forward")
+    return build_apply_binding(apply_offset, BUTTON_TYPE_MOUSE,
+                               modifier=val, page=page)
 
 
 def build_forward_back(apply_offset: int, forward: bool, page: int = 0x00) -> bytes:
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,
-            0x01,
-            0x10 if forward else 0x08,
-            0x00,
-            0x44 if forward else 0x4C,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_mouse_param(apply_offset, 0x10 if forward else 0x08, page)
+
+
+def build_dpi_control(apply_offset: int, function: int,
+                      page: int = 0x00) -> bytes:
+    if function not in (1, 2, 3):
+        raise ValueError("DPI function must be 1=loop, 2=up, or 3=down")
+    return build_apply_binding(apply_offset, BUTTON_TYPE_DPI_LEGACY,
+                               modifier=function, page=page)
 
 
 def build_special_binding(apply_offset: int, delay_ms: int, repeat_count: int, page: int = 0x00) -> bytes:
@@ -804,7 +741,8 @@ def build_special_binding(apply_offset: int, delay_ms: int, repeat_count: int, p
         apply_offset: Button's mouse region offset (e.g., 0x6C for button 4)
         delay_ms: Delay between repeats in milliseconds (0-255)
         repeat_count: Number of repeats (0-255)
-        page: Memory page (0x00 for Profile 1, 0x40 for Profile 2, etc.)
+        page: High byte of the destination address. Areson Venus Pro devices
+            have only one exposed profile, whose action table is on page 0.
     
     Format from Windows capture:
     - Type = 0x04, D1 = delay_ms, D2 = repeat_count
@@ -815,25 +753,8 @@ def build_special_binding(apply_offset: int, delay_ms: int, repeat_count: int, p
     d2 = repeat_count & 0xFF
     d3 = (0x55 - (btype + d1 + d2)) & 0xFF
     
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,  # Length
-            btype,
-            d1,
-            d2,
-            d3,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_memory_write(((page & 0xFF) << 8) | apply_offset,
+                              bytes((btype, d1, d2, d3)))
 
 
 def build_poll_rate_toggle(apply_offset: int, page: int = 0x00) -> bytes:
@@ -842,25 +763,8 @@ def build_poll_rate_toggle(apply_offset: int, page: int = 0x00) -> bytes:
     d1, d2 = 0x00, 0x00
     d3 = (0x55 - (btype + d1 + d2)) & 0xFF  # = 0x4E
     
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,
-            btype,
-            d1,
-            d2,
-            d3,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_memory_write(((page & 0xFF) << 8) | apply_offset,
+                              bytes((btype, d1, d2, d3)))
 
 
 def build_rgb_toggle(apply_offset: int, page: int = 0x00) -> bytes:
@@ -869,48 +773,14 @@ def build_rgb_toggle(apply_offset: int, page: int = 0x00) -> bytes:
     d1, d2 = 0x00, 0x00
     d3 = (0x55 - (btype + d1 + d2)) & 0xFF  # = 0x4D
     
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,
-            btype,
-            d1,
-            d2,
-            d3,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_memory_write(((page & 0xFF) << 8) | apply_offset,
+                              bytes((btype, d1, d2, d3)))
 
 
 def build_disabled(apply_offset: int, page: int = 0x00) -> bytes:
     """Build a disabled binding for a button."""
-    payload = bytes(
-        [
-            0x00,
-            page,
-            apply_offset,
-            0x04,
-            BUTTON_TYPE_DISABLED,  # 0x00
-            0x00,
-            0x00,
-            0x55,  # Validation byte
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_memory_write(((page & 0xFF) << 8) | apply_offset,
+                              bytes((BUTTON_TYPE_DISABLED, 0, 0, 0x55)))
 
 
 @dataclass(frozen=True)
@@ -919,6 +789,13 @@ class MacroEvent:
     is_down: bool
     delay_ms: int
     is_modifier: bool = False  # Modifiers use different status codes
+    event_type: str = "keyboard"  # keyboard, modifier, or mouse
+
+    @classmethod
+    def mouse(cls, button_mask: int, is_down: bool, delay_ms: int) -> "MacroEvent":
+        if button_mask not in (0x01, 0x02, 0x04, 0x08, 0x10):
+            raise ValueError("unsupported macro mouse-button mask")
+        return cls(button_mask, is_down, delay_ms, False, "mouse")
 
     def to_bytes(self) -> bytes:
         """Convert to the 5-byte format expected by the mouse hardware.
@@ -927,53 +804,70 @@ class MacroEvent:
         Status codes:
         - 0x81 = Key Down, 0x41 = Key Up (regular keys)
         - 0x80 = Modifier Down, 0x40 = Modifier Up (Shift, Ctrl, Alt)
+        - 0x84 = Mouse Down, 0x44 = Mouse Up
+
+        The vendor converter accepts event classes 0, 1, and 4 only.  Relative
+        mouse movement is therefore not representable in this format.
         """
-        if self.is_modifier:
+        if not 0 <= self.delay_ms <= 0xFFFF:
+            raise ValueError("macro delay must be 0..65535 ms")
+        event_type = "modifier" if self.is_modifier else self.event_type
+        if event_type == "mouse":
+            if self.keycode not in (0x01, 0x02, 0x04, 0x08, 0x10):
+                raise ValueError("invalid mouse-button mask")
+            status = 0x84 if self.is_down else 0x44
+        elif event_type == "modifier":
             status = 0x80 if self.is_down else 0x40
-        else:
+        elif event_type == "keyboard":
             status = 0x81 if self.is_down else 0x41
+        else:
+            raise ValueError(f"unsupported macro event type: {event_type}")
         return bytes([status, self.keycode, 0x00, (self.delay_ms >> 8) & 0xFF, self.delay_ms & 0xFF])
 
 
+def build_macro_image(name: str, events: Iterable[MacroEvent]) -> bytes:
+    """Serialize one complete, unpadded 0x180-byte-slot macro image.
+
+    EEPROM writes may contain fewer than ten data bytes, so padding the final
+    chunk is unnecessary.  In particular, padding a 69-event image would grow
+    it from 381 to 390 bytes and corrupt the following slot.
+    """
+    event_list = tuple(events)
+    if len(event_list) > MACRO_MAX_EVENTS:
+        raise ValueError(
+            f"a macro slot holds at most {MACRO_MAX_EVENTS} events")
+
+    encoded_name = bytearray()
+    for character in name:
+        encoded_character = character.encode("utf-16-le")
+        if len(encoded_name) + len(encoded_character) > 30:
+            break
+        encoded_name.extend(encoded_character)
+    name_bytes = bytes(encoded_name)
+    header = (
+        bytes((len(name_bytes),))
+        + name_bytes.ljust(30, b"\x00")
+        + bytes((len(event_list),))
+    )
+    event_bytes = b"".join(event.to_bytes() for event in event_list)
+    checksum = calculate_terminator_checksum(header + event_bytes,
+                                             len(event_list))
+    image = header + event_bytes + bytes((checksum, 0, 0, 0))
+    if len(image) > MACRO_SLOT_SIZE:
+        raise ValueError("serialized macro exceeds its EEPROM slot")
+    return image
+
+
 def build_macro_chunk(offset: int, chunk: bytes, macro_page: int = 0x03) -> bytes:
-    """Build a macro data chunk packet.
+    """Build one write into the absolute macro storage region.
     
     Args:
         offset: Byte offset within the macro data region
         chunk: The data bytes to write (max 10 bytes)
-        macro_page: Memory page for macro storage. 
-                   From captures: button 1 uses 0x03, button 11 uses 0x18
+        macro_page: High byte of the absolute macro address. Slots have a
+            stride of ``0x180``, so odd slots begin at offset ``0x80``.
     """
-    if len(chunk) > 10:
-        raise ValueError("macro chunk must be <= 10 bytes")
-    chunk_len = len(chunk)
-    padded = chunk.ljust(10, b"\x00")
-    payload = bytes([0x00, macro_page & 0xFF, offset & 0xFF, chunk_len & 0xFF, *padded])
-    return build_report(0x07, payload)
-
-
-def build_flash_write(page: int, offset: int, data: bytes) -> bytes:
-    """Write data to flash memory.
-    
-    This is a generic wrapper around the same packet structure used for macros.
-    Max 10 bytes per packet.
-    """
-    return build_macro_chunk(offset, data, page)
-
-
-
-def get_macro_page(apply_offset: int) -> int:
-    """Calculate the macro memory page for a button.
-    
-    With contiguous button offsets (0x60-0x9C), the flash_index is simply:
-    flash_index = (apply_offset - 0x60) // 4
-    
-    Macros are stored starting at page 0x03, with each button getting dedicated pages.
-    From memory dumps, macros appear in slots starting at page 0x03.
-    """
-    flash_index = (apply_offset - 0x60) // 4
-    # Simple linear mapping: button 0 -> page 0x03, button 1 -> page 0x04, etc.
-    return 0x03 + flash_index
+    return build_memory_write(((macro_page & 0xFF) << 8) | (offset & 0xFF), chunk)
 
 
 def build_macro_terminator(offset: int, checksum: int, macro_page: int = 0x03) -> bytes:
@@ -984,7 +878,7 @@ def build_macro_terminator(offset: int, checksum: int, macro_page: int = 0x03) -
 
     Args:
         offset: Byte offset where terminator should be written (after last event)
-        checksum: Calculated checksum using formula: (~sum(data) - count + (index+1)^2) & 0xFF
+        checksum: ``(0x55 - event_count - sum(event_bytes)) & 0xff``.
         macro_page: Memory page for macro storage
     """
     tail = bytes([checksum, 0x00, 0x00, 0x00])
@@ -1000,10 +894,12 @@ def build_macro_bind(apply_offset: int, index: int, repeat: int = 0x01, page: in
     - D2 = repeat count (1-253) or mode (0xFE=Hold, 0xFF=Toggle)
     - Chk = 0x55 - sum(bytes 0-2)
     """
-    btype = 0x06
-    chk = (0x55 - (btype + index + repeat)) & 0xFF
-    data = bytes([btype, index, repeat, chk, 0x00, 0x00, 0x00, 0x00])
-    return build_flash_write(0x00, apply_offset, data)
+    if not 0 <= index <= 0x0F:
+        raise ValueError("macro index must be 0..15")
+    if not 1 <= repeat <= 0xFF:
+        raise ValueError("macro repeat must be 1..255")
+    return build_apply_binding(apply_offset, BUTTON_TYPE_MACRO,
+                               action_index=repeat, modifier=index, page=page)
 
 
 def get_macro_slot_info(macro_index: int) -> tuple[int, int]:
@@ -1012,6 +908,8 @@ def get_macro_slot_info(macro_index: int) -> tuple[int, int]:
     Each slot is 384 bytes (0x180).
     Base Address for Macro 0 (Index 0) is Page 0x03, Offset 0x00 (0x300).
     """
+    if not 0 <= macro_index <= 15:
+        raise ValueError("macro index must be 0..15")
     base_addr = 0x300
     stride = 0x180
     
@@ -1023,254 +921,355 @@ def get_macro_slot_info(macro_index: int) -> tuple[int, int]:
 
 
 def build_dpi(slot_index: int, value: int, tweak: int) -> bytes:
-    if not 0 <= slot_index <= 4:
-        raise ValueError("slot_index must be 0..4")
+    if not 0 <= slot_index <= 7:
+        raise ValueError("slot_index must be 0..7")
     offset = 0x0C + (slot_index * 4)
-    payload = bytes(
-        [
-            0x00,
-            0x00,
-            offset & 0xFF,
-            0x04,
-            value & 0xFF,
-            value & 0xFF,
-            0x00,
-            tweak & 0xFF,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
-    )
-    return build_report(0x07, payload)
+    return build_memory_write(offset, bytes((value & 0xFF, value & 0xFF,
+                                             0x00, tweak & 0xFF)))
 
 
 @dataclass(frozen=True)
 class DeviceInfo:
-    path: str
+    path: bytes | str
     product: str
     manufacturer: str
     vendor_id: int
     product_id: int
     serial: str
-    interface_number: int = 0  # Added to track interface
+    interface_number: int = -1
+    usage_page: int = 0
+    usage: int = 0
+    access_error: str = ""
+    selection_note: str = ""
+
+    @property
+    def display_path(self) -> str:
+        if isinstance(self.path, bytes):
+            return self.path.decode(errors="backslashreplace")
+        return self.path
 
 
-def _device_sort_key(info: DeviceInfo) -> tuple[int, int, str]:
+@dataclass(frozen=True)
+class BatteryStatus:
+    level: int
+    percent: int
+    cable_connected: bool
+    raw: bytes
+
+
+class DeviceAccessError(RuntimeError):
+    pass
+
+
+class ProtocolError(RuntimeError):
+    pass
+
+
+class ProtocolTimeout(ProtocolError):
+    pass
+
+
+def expected_interface(vendor_id: int, product_id: int) -> int:
+    return 2 if (vendor_id, product_id) == (0x04D9, 0xFC55) else 1
+
+
+def expected_usage_page(vendor_id: int, product_id: int) -> int:
+    return 0xFFA0 if (vendor_id, product_id) == (0x04D9, 0xFC55) else 0xFF02
+
+
+def _format_open_error(path: bytes | str, exc: BaseException) -> str:
+    shown = path.decode(errors="backslashreplace") if isinstance(path, bytes) else str(path)
+    detail = str(exc).strip() or exc.__class__.__name__
+    lowered = detail.lower()
+    if "permission" in lowered or "access denied" in lowered:
+        return (f"Permission denied opening {shown}. Install 99-venus-pro.rules, "
+                "reload udev rules, then unplug and reconnect the mouse/receiver.")
+    return (f"Cannot open config interface {shown}: {detail}. Check the udev ACL "
+            "and close Wine, virtual machines, or capture tools that may have claimed it.")
+
+
+def _probe_open(path: bytes | str) -> str:
+    if not HIDAPI_AVAILABLE:
+        return "python-hidapi is not installed"
+    handle = None
+    try:
+        handle = hid.device()
+        raw_path = path.encode() if isinstance(path, str) else path
+        handle.open_path(raw_path)
+        return ""
+    except Exception as exc:
+        return _format_open_error(path, exc)
+    finally:
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception:
+                pass
+
+
+def _device_sort_key(info: DeviceInfo) -> tuple[int, int, int, str]:
     product_lower = info.product.lower()
     # Check string OR explicit PID for receiver
     is_receiver = "receiver" in product_lower or info.product_id == 0xFA07
 
-    # Holtek devices (VID 0x04D9) use interface 2 for config
-    is_holtek = info.vendor_id == 0x04D9
-
-    if is_holtek:
-        if info.interface_number == 2:
-            interface_rank = 0
-        else:
-            interface_rank = 2
-    else:
-        if info.interface_number == 1:
-            interface_rank = 0
-        elif info.interface_number == 0:
-            interface_rank = 1
-        else:
-            interface_rank = 2
-    return (1 if is_receiver else 0, interface_rank, info.product)
+    wanted = expected_interface(info.vendor_id, info.product_id)
+    interface_rank = 0 if info.interface_number == wanted else 1
+    access_rank = 1 if info.access_error else 0
+    return (access_rank, 1 if is_receiver else 0, interface_rank, info.product)
 
 
 def list_devices(exclude_receivers: bool = False) -> list[DeviceInfo]:
-    devices = []
-    found = []
-    found_by_enum = set()  # Track (vid, pid) combos found via enumeration
+    """Enumerate only usable vendor configuration interfaces.
 
-    # Try enumeration first to get full details (path, interface number)
-    try:
-        for vid in VENDOR_IDS:
-            devs = hid.enumerate(vid, 0)
-            for d in devs:
-                if d['product_id'] in PRODUCT_IDS:
-                    found.append(d)
-                    found_by_enum.add((d['vendor_id'], d['product_id']))
-    except:
-        pass
+    A HID device exposes separate mouse, keyboard, and vendor interfaces.  The
+    old fallback opened by VID/PID and then fabricated an unusable path, which
+    is the direct cause of many ``open failed`` reports.  Linux hidapi always
+    supplies a real hidraw path, so entries without one are never returned.
+    """
+    if not HIDAPI_AVAILABLE:
+        return []
 
-    # Fallback: try direct open for VID/PIDs not found by enumeration.
-    # This is necessary for some systems (e.g., macOS) where hid.enumerate()
-    # might not return all necessary details or might fail for certain devices.
-    for vid in VENDOR_IDS:
-        for pid in PRODUCT_IDS:
-            if (vid, pid) in found_by_enum:
+    devices: list[DeviceInfo] = []
+    for vid, pid in sorted(SUPPORTED_DEVICE_IDS):
+        try:
+            entries = list(hid.enumerate(vid, pid))
+        except Exception:
+            continue
+        if not entries:
+            continue
+
+        wanted_interface = expected_interface(vid, pid)
+        wanted_page = expected_usage_page(vid, pid)
+        exact = [entry for entry in entries
+                 if entry.get("interface_number", -1) == wanted_interface]
+        usage_matches = [entry for entry in entries
+                         if entry.get("usage_page", 0) == wanted_page]
+        unknown_interface = [entry for entry in entries
+                             if entry.get("interface_number", -1) < 0]
+        unknown_paths = {entry.get("path") for entry in unknown_interface
+                         if entry.get("path")}
+
+        if exact:
+            exact_vendor_usage = [entry for entry in exact
+                                  if entry.get("usage_page", 0) == wanted_page]
+            candidates = exact_vendor_usage or exact
+            note = ""
+        elif usage_matches:
+            candidates = usage_matches
+            note = "Selected by vendor usage page; interface number was unavailable."
+        elif len(unknown_paths) == 1:
+            candidates = unknown_interface
+            note = "Interface metadata unavailable; selected the only HID candidate."
+        else:
+            # Do not open the boot mouse/keyboard interfaces and pretend they
+            # are configuration paths.
+            continue
+
+        seen_paths: set[bytes | str] = set()
+        for item in candidates:
+            path = item.get("path")
+            if not path or path in seen_paths:
                 continue
-            try:
-                h = hid.device()
-                h.open(vid, pid)
-                found.append({
-                    'vendor_id': vid,
-                    'product_id': pid,
-                    'path': b"Unknown (hidapi open)",
-                    'interface_number': -1
-                })
-                h.close()
-            except IOError:
+            seen_paths.add(path)
+            product = item.get("product_string") or DEVICE_NAMES.get((vid, pid), "Unknown")
+            if exclude_receivers and (pid == 0xFA07 or "receiver" in product.lower()):
                 continue
-            except Exception:
-                continue
-
-    seen_paths = set()
-    for item in found:
-        if item["product_id"] not in PRODUCT_IDS:
-            continue
-
-        product = item.get("product_string") or "Unknown"
-
-        # Filter out "Wireless Receiver" only when explicitly requested.
-        if exclude_receivers and "receiver" in product.lower():
-            continue
-
-        # Accept interfaces 0, 1, 2 (generic HID config interface on Holtek variants)
-        # and -1 for fallback direct-open entries
-        interface = item.get("interface_number", -1)
-        if interface not in [-1, 0, 1, 2]:
-            continue
-        
-        path_str = item["path"].decode() if isinstance(item["path"], bytes) else item["path"]
-            
-        if path_str in seen_paths:
-            continue
-        seen_paths.add(path_str)
-
-        devices.append(
-            DeviceInfo(
-                path=path_str,
+            devices.append(DeviceInfo(
+                path=path,
                 product=product,
                 manufacturer=item.get("manufacturer_string") or "Unknown",
-                vendor_id=item["vendor_id"],
-                product_id=item["product_id"],
+                vendor_id=vid,
+                product_id=pid,
                 serial=item.get("serial_number") or "",
-                interface_number=interface,
-            )
-        )
-        
-    # Sort devices: non-receiver first, then preferred interface (1 before 0).
+                interface_number=item.get("interface_number", -1),
+                usage_page=item.get("usage_page", 0),
+                usage=item.get("usage", 0),
+                access_error=_probe_open(path),
+                selection_note=note,
+            ))
+
     devices.sort(key=_device_sort_key)
-    
     return devices
 
 
 class VenusDevice:
-    def __init__(self, path: str):
+    # Interrupt responses are consumed from one hidraw queue. Serializing
+    # handles prevents the tray poller from stealing a configuration ACK.
+    _io_lock = threading.Lock()
+
+    def __init__(self, path: bytes | str):
         self._path = path
-        self._dev: Optional[hid.device] = None
+        self._dev = None
+        self._lock_held = False
+        self.last_error = ""
 
     def open(self) -> None:
         if self._dev is not None:
             return
-        dev = hid.device()
-        dev.open_path(self._path.encode() if isinstance(self._path, str) else self._path)
-        dev.set_nonblocking(True)
-        self._dev = dev
+        if not HIDAPI_AVAILABLE:
+            raise DeviceAccessError("python-hidapi is not installed")
+        if not self._io_lock.acquire(timeout=1.0):
+            raise DeviceAccessError("mouse configuration interface is busy")
+        self._lock_held = True
+        dev = None
+        try:
+            dev = hid.device()
+            dev.open_path(self._path.encode() if isinstance(self._path, str) else self._path)
+            dev.set_nonblocking(True)
+            self._dev = dev
+        except Exception as exc:
+            try:
+                if dev is not None:
+                    dev.close()
+            except Exception:
+                pass
+            self._io_lock.release()
+            self._lock_held = False
+            raise DeviceAccessError(_format_open_error(self._path, exc)) from exc
 
     def close(self) -> None:
         if self._dev is None:
             return
-        self._dev.close()
-        self._dev = None
+        try:
+            self._dev.close()
+        finally:
+            self._dev = None
+            if self._lock_held:
+                self._io_lock.release()
+                self._lock_held = False
 
     def send(self, report: bytes) -> None:
         if self._dev is None:
             raise RuntimeError("device not open")
         if len(report) != REPORT_LEN:
             raise ValueError(f"report must be {REPORT_LEN} bytes")
-        self._dev.send_feature_report(report)
+        if report[0] != REPORT_ID or not report_checksum_valid(report):
+            raise ValueError("invalid Areson feature report")
+        written = self._dev.send_feature_report(report)
+        if written is not None and written <= 0:
+            raise ProtocolError("hidapi rejected the feature report")
 
-    def send_reliable(self, report: bytes, timeout_ms: int = 500) -> bool:
-        """Sends a Feature Report (0x08) and waits for acknowledgment (0x09)."""
-        self.send(report)
-        
-        cmd = report[1]
-        # For bulk writes (Cmd 07), we also want to match Page and Offset if possible
-        page = report[3]
-        off = report[4]
-        
-        start = time.time()
-        while (time.time() - start) * 1000 < timeout_ms:
-            resp = self._dev.read(64, timeout_ms=50)
-            if resp and resp[0] == 0x09 and resp[1] == cmd:
-                # If it's a memory write, verify page/offset too
-                if cmd == 0x07:
-                    if resp[3] == page and resp[4] == off:
-                        return True
-                else:
-                    return True
-        return False
-
-    def unlock(self) -> bool:
-        """Sends the Magic Unlock sequence (Cmd 09, 4D, 01) reliably."""
-        if self._dev is None:
-            return False
-            
-        try:
-            # 1. Reset (Cmd 09)
-            self.send_reliable(build_simple(0x09))
-            
-            # 2. Magic Packet 1 (Cmd 4D)
-            magic1 = bytes([0x08, 0x4D, 0x05, 0x50, 0x00, 0x55, 0x00, 0x55, 0x00, 0x55, 0x91])
-            self.send_reliable(magic1.ljust(17, b'\x00'))
-            
-            # 3. Magic Packet 2 (Cmd 01)
-            magic2 = bytes([0x08, 0x01, 0x00, 0x00, 0x00, 0x04, 0x56, 0x57, 0x3d, 0x1b, 0x00, 0x00])
-            self.send_reliable(magic2.ljust(17, b'\x00'))
-            
-            return True
-        except Exception as e:
-            print(f"Unlock failed: {e}")
-            return False
-
-    def read_flash(self, page: int, offset: int, length: int) -> bytes:
-        """Read 8 bytes from flash memory at the given page and offset.
-        
-        Note: Currently fixed to 8 bytes per read to ensure reliability.
-        """
+    def _read(self, length: int, timeout_ms: int) -> bytes:
         if self._dev is None:
             raise RuntimeError("device not open")
-        
-        # Flush any pending reports
-        while True:
-            r = self._dev.read(128, timeout_ms=10)
-            if not r:
-                break
-        
+        try:
+            value = self._dev.read(length, timeout_ms)
+        except TypeError:
+            value = self._dev.read(length, timeout_ms=timeout_ms)
+        return bytes(value or ())
+
+    def flush_input(self) -> None:
+        if self._dev is None:
+            return
+        while self._read(64, 1):
+            pass
+
+    def exchange(self, report: bytes, timeout_ms: int = 500) -> bytes:
+        """Send report 0x08 and return its matching interrupt response 0x09."""
+        self.flush_input()
+        self.send(report)
+        command = report[1]
+        address = report[3:5]
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        invalid_checksum_seen = False
+        while time.monotonic() < deadline:
+            remaining = max(1, int((deadline - time.monotonic()) * 1000))
+            response = self._read(64, min(50, remaining))
+            if not response:
+                continue
+            if len(response) < REPORT_LEN:
+                continue
+            response = response[:REPORT_LEN]
+            if response[0] != RESPONSE_REPORT_ID or response[1] != command:
+                continue
+            if command in (CMD_WRITE, CMD_READ) and response[3:5] != address:
+                continue
+            if not report_checksum_valid(response):
+                invalid_checksum_seen = True
+                continue
+            return response
+        suffix = " (a response had a bad checksum)" if invalid_checksum_seen else ""
+        raise ProtocolTimeout(f"command 0x{command:02x} timed out{suffix}")
+
+    def send_reliable(self, report: bytes, timeout_ms: int = 500) -> bool:
+        """Compatibility boolean wrapper around :meth:`exchange`."""
+        try:
+            self.exchange(report, timeout_ms)
+            self.last_error = ""
+            return True
+        except Exception as exc:
+            self.last_error = str(exc)
+            return False
+
+    def ready(self) -> bool:
+        response = self.exchange(build_simple(CMD_READY))
+        return response[5] >= 1 and response[6] == 1
+
+    def authenticate(self, challenge: bytes | None = None) -> bool:
+        if challenge is None:
+            challenge = bytes(secrets.randbelow(100) + 1 for _ in range(4))
+        response = self.exchange(build_challenge(challenge))
+        return response[5] == 4 and response[6:10] == challenge_response(challenge)
+
+    def enable_notifications(self) -> bool:
+        response = self.exchange(build_notify_enable())
+        return response[5] == 1 and response[6] == 1
+
+    def start_session(self) -> bool:
+        """Run the non-destructive startup sequence used by the Windows app."""
+        if not self.ready() or not self.authenticate():
+            return False
+        self.read_flash(0x00, 0x04, 2)
+        return self.enable_notifications()
+
+    def begin_write(self) -> bool:
+        """Request ready state before one or more immediately-persistent writes."""
+        return self.ready()
+
+    def unlock(self) -> bool:
+        """Deprecated safe alias for :meth:`start_session`."""
+        try:
+            return self.start_session()
+        except Exception as exc:
+            self.last_error = str(exc)
+            return False
+
+    def query_status(self) -> BatteryStatus:
+        """Read battery level (0..10) and cable/power-source flag."""
+        response = self.exchange(build_simple(CMD_STATUS))
+        if response[5] < 2:
+            raise ProtocolError("status response is shorter than two bytes")
+        level = response[6]
+        if level > 10:
+            raise ProtocolError(f"invalid battery step {level}; expected 0..10")
+        percent = level * 10
+        return BatteryStatus(level, percent, bool(response[7]), response[6:8])
+
+    def factory_reset(self) -> None:
+        """Erase settings and macros.  Call only after explicit confirmation."""
+        self.exchange(build_simple(CMD_FACTORY_RESET), timeout_ms=1000)
+
+    def read_flash(self, page: int, offset: int, length: int) -> bytes:
+        """Read up to ten bytes from an EEPROM page/offset."""
+        if self._dev is None:
+            raise RuntimeError("device not open")
         req = build_flash_read(page, offset, length)
-        self._dev.send_feature_report(req)
-        
-        # Responses arrive on Interrupt endpoint, Report ID 0x09
-        # Wait up to 100ms for response
-        start_time = time.time()
-        while (time.time() - start_time) < 0.2: # 200ms timeout
-            resp = self._dev.read(128, timeout_ms=50)
-            if resp and resp[0] == 0x09 and resp[1] == 0x08:
-                # Format: 09 08 00 [page] [offset] [len] [data...]
-                # Check consistency
-                if resp[3] == page and resp[4] == offset:
-                    # Successfully read data
-                    data_len = resp[5]
-                    return bytes(resp[6 : 6 + data_len])
-        
-        raise RuntimeError(f"Flash read timeout at Page=0x{page:02X} Offset=0x{offset:02X}")
+        response = self.exchange(req)
+        data_len = response[5]
+        if data_len != length or data_len > MAX_DATA_LEN:
+            raise ProtocolError(
+                f"read at 0x{page:02x}{offset:02x} returned invalid length {data_len}")
+        return response[6:6 + data_len]
 
 
 def calculate_terminator_checksum(
     data: bytes,
     event_count: int | None = None,
 ) -> int:
-    """
-    Calculate the macro terminator checksum.
+    """Calculate the checksum byte that immediately follows macro events.
 
-    Verified from working Windows macros:
-      checksum = (~sum(events) - event_count + 0x56) & 0xFF
+    The equivalent compact formula is
+    ``(0x55 - event_count - sum(events)) & 0xff``.
     """
     if event_count is None:
         event_count = data[0x1F] if len(data) > 0x1F else 0
@@ -1282,20 +1281,4 @@ def calculate_terminator_checksum(
     else:
         events = data[events_start:events_end]
 
-    s_sum = sum(events) & 0xFF
-    inv_sum = (~s_sum) & 0xFF
-    return (inv_sum - event_count + 0x56) & 0xFF
-
-
-def get_macro_slot_info(index: int) -> tuple[int, int]:
-    """Returns (page, offset) for a given macro index (0-based).
-    Stride is 384 bytes (0x180), NOT 256 bytes.
-    Base Address is 0x300 (Page 3, Offset 0).
-    """
-    base_addr = 0x300
-    stride = 0x180
-    abs_addr = base_addr + (index * stride)
-    
-    page = (abs_addr >> 8) & 0xFF
-    offset = abs_addr & 0xFF
-    return page, offset
+    return (CHECKSUM_BASE - event_count - sum(events)) & 0xFF

--- a/venusprolinux.install
+++ b/venusprolinux.install
@@ -1,0 +1,10 @@
+# shellcheck shell=bash
+
+post_install() {
+    udevadm control --reload-rules 2>/dev/null || true
+    echo "Reconnect the Venus mouse/receiver to apply its uaccess ACL."
+}
+
+post_upgrade() {
+    post_install
+}


### PR DESCRIPTION
## What changed

- Replaced the guessed Areson command flow with capture- and binary-backed framing, checksums, startup authentication, status reads, EEPROM addressing, button records, definition slots, macros, DPI, polling, and lighting builders.
- Added reliable selection of the vendor configuration HID interface, actionable access errors, safe udev rules, and a read-only diagnostic for the wired, wireless, and Holtek variants.
- Added a cross-desktop battery tray icon and a minimum-brightness red/yellow/green mouse-LED battery controller that runs while the app is hidden and restores manual lighting on normal exit.
- Added native left/right/middle mouse events to the macro editor and fixed maximum-size macro slot overflow and custom Neon mode encoding.
- Added Arch manual guidance, an AUR-facing VCS PKGBUILD, launcher, install hook, desktop metadata, protocol documentation, capture decoder, Ghidra reproduction scripts, and hardware-safe regression tests.
- Prevented the automatic startup read from opening a hidden modal dialog that disabled the main interface when it was opened from the tray.

## Why

The former implementation mixed two unrelated device protocols, selected the wrong HID collection on some systems, treated status as a write commit, contained guessed reset/unlock behavior, and encoded several records incorrectly. This caused detection/open failures and made some configuration paths unsafe or unreliable.

## Hardware boundaries found

- Areson `25a7:fa07/fa08` does not expose its two physical top DPI buttons in the writable action table, so those appear firmware-fixed.
- Holtek `04d9:fc55` does expose DPI Up/Down and permits rebinding them.
- The vendor macro converter accepts native mouse-button events but exposes no accepted relative-movement event class.

Addresses #4, #6, #7, #8, and #9.

## Validation

- 32 maintained unit and headless GUI tests
- Python byte-compilation
- ShellCheck and shell syntax validation
- desktop-file, offline AppStream, and udev rule validation
- Arch `.SRCINFO` reproduction
- capture decoder checks against the bundled USBPcap traces
- read-only live query of `25a7:fa07` interface 1: access OK, 60% wireless battery response

No live EEPROM or lighting writes were performed during validation.
