### PR TITLE
Add hardware macro modifier support

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -299,6 +299,24 @@ encode class:
 | `81/41` | keyboard |
 | `84/44` | mouse button |
 
+The macro modifier code is a vendor key code, not the standard HID modifier
+bit used in the separate event-definition area:
+
+| Macro code | Modifier |
+|---:|---|
+| `01` | Left Ctrl |
+| `02` | Left Shift |
+| `04` | Left Alt |
+| `08` | Left or right GUI/Super |
+| `10` | Right Ctrl |
+| `20` | Right Shift |
+| `40` | Right Alt |
+
+These values come directly from both conversion directions in the Windows
+driver (`StMacro_To_HdMacro` and `HdMacro_To_StMacro`). The GUI/Super keys are
+intentionally collapsed by that converter; the other modifiers retain their
+left/right identity. **Binary**
+
 Mouse event codes use the same `01/02/04/08/10` button masks. The bundled UI
 enables the first three through `MacroHasMsKey=0x07`; the converter itself also
 recognizes back and forward. It rejects other event classes, and the fixed
@@ -322,9 +340,11 @@ sample each gap from a user-selected range, then stores those sampled values as
 ordinary fixed event delays. Randomness is not a firmware playback feature.
 
 US-layout unshifted characters consume two events. Shifted characters consume
-four and use modifier event code `20`, the value seen in captured macro data.
-The editor rejects unsupported text or output above 69 events before writing.
-**Capture-backed serialization; builder timing policy**
+four. The text builder retains modifier event code `20` (Right Shift) to match
+captured vendor output, while the recorder and manual editor accept every code
+in the table above. The editor rejects unsupported text or output above 69
+events before writing. **Capture-backed serialization, Binary; builder timing
+policy**
 
 Macro action repeat byte:
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ If your device reports a different ID, verify support before assuming compatibil
 
 - **Button Remapping:** Configure 16 Areson controls or all 19 mapped Holtek
   controls, including the 12-button side panel.
-- **Modifier Support:** On Areson, bind combinations such as `Ctrl+Shift+1`
-  and `Alt+F1`.
+- **Modifier Support:** On Areson, bind or record combinations such as
+  `Ctrl+Shift+1`, `Alt+F1`, and `Ctrl+Alt+Delete`; hardware macros preserve
+  modifier press/release order and left/right identity where the protocol does.
 - **Macro Engine:** Slot-oriented editor with recording, reordering, duplication,
   exact capacity feedback, and fixed or randomized timing.
 - **Text Macros:** Convert US-layout text with separate key-hold, inter-key,
@@ -110,9 +111,10 @@ Holtek device is connected.
 ### Macros tab
 
 Build text with fixed or randomized inter-key delays, append or replace events,
-record supported keys, reorder steps, and see the exact 69-event hardware
-capacity before saving. See the [macro editor guide](docs/MACRO_EDITOR.md) for
-timing semantics and hardware limits.
+record keyboard shortcuts with Ctrl/Shift/Alt/GUI, reorder steps, and see the
+exact 69-event hardware capacity before saving. See the
+[macro editor guide](docs/MACRO_EDITOR.md) for timing semantics and hardware
+limits.
 
 ![Macros tab](Macros.png)
 

--- a/docs/MACRO_EDITOR.md
+++ b/docs/MACRO_EDITOR.md
@@ -43,14 +43,17 @@ generate new random delays during playback.
 ## Recording and manual events
 
 **Record** captures supported keyboard press/release events and the elapsed
-time after the preceding event. Shift is the only macro modifier confirmed in
-the supplied vendor data. Ctrl, Alt, and Meta combinations are skipped with a
-visible warning rather than being recorded incorrectly.
+time after the preceding event. Ctrl, Shift, Alt, and GUI/Super modifier
+presses and releases are stored as their own hardware events, so combinations
+such as Ctrl+C and Ctrl+Alt+Delete preserve their ordering and timing. Left and
+right Ctrl, Shift, and Alt have separate vendor codes when Qt supplies enough
+native key information to distinguish them. The firmware has only one shared
+GUI/Super code.
 
 The **Manual Events** builder can add:
 
 - keyboard keys;
-- the confirmed Shift modifier event;
+- left/right Ctrl, Shift, and Alt plus the shared GUI/Super modifier;
 - left, right, middle, back, and forward mouse-button masks;
 - a complete tap, a press only, or a release only.
 

--- a/tests/test_areson_protocol_offline.py
+++ b/tests/test_areson_protocol_offline.py
@@ -147,6 +147,29 @@ class ProtocolBuilderTests(unittest.TestCase):
         checksum = vp.calculate_terminator_checksum(header + events, 2)
         self.assertEqual((2 + sum(events) + checksum) & 0xFF, 0x55)
 
+    def test_macro_modifier_codes_match_vendor_converter(self):
+        expected = {
+            "Left Ctrl": 0x01,
+            "Left Shift": 0x02,
+            "Left Alt": 0x04,
+            "GUI": 0x08,
+            "Right Ctrl": 0x10,
+            "Right Shift": 0x20,
+            "Right Alt": 0x40,
+        }
+        self.assertEqual(vp.MACRO_MODIFIER_CODES, expected)
+        for code in expected.values():
+            self.assertEqual(
+                vp.MacroEvent(
+                    code, True, 3, True, "modifier").to_bytes(),
+                bytes((0x80, code, 0x00, 0x00, 0x03)),
+            )
+            self.assertEqual(
+                vp.MacroEvent(
+                    code, False, 3, True, "modifier").to_bytes(),
+                bytes((0x40, code, 0x00, 0x00, 0x03)),
+            )
+
     def test_text_macro_uses_captured_shift_order_and_timing(self):
         self.assertEqual(vp.text_macro_requirements("aA!"), (10, ()))
         events = vp.build_text_macro_events(

--- a/tests/test_macro_editor.py
+++ b/tests/test_macro_editor.py
@@ -11,7 +11,7 @@ from unittest import mock
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
-    from PyQt6 import QtWidgets
+    from PyQt6 import QtCore, QtGui, QtWidgets
 
     import venus_gui as gui
     import venus_protocol as vp
@@ -92,6 +92,97 @@ class MacroEditorTests(unittest.TestCase):
         )
         self.assertIn("[Left click]", self.window.macro_preview_label.text())
         self.assertNotIn("still pressed", self.window.macro_preview_label.text())
+
+    def test_manual_builder_exposes_every_hardware_modifier(self):
+        modifier_items = {}
+        for index in range(self.window.add_key_combo.count()):
+            event_data = self.window.add_key_combo.itemData(index)
+            if event_data and event_data[0] == "modifier":
+                modifier_items[self.window.add_key_combo.itemText(index)] = (
+                    event_data[1])
+
+        self.assertEqual(
+            modifier_items,
+            {
+                f"Modifier: {name}": code
+                for name, code in vp.MACRO_MODIFIER_CODES.items()
+            },
+        )
+
+    def test_recording_ctrl_c_keeps_modifier_press_and_release(self):
+        self.window._toggle_recording(True)
+        events = (
+            QtGui.QKeyEvent(
+                QtCore.QEvent.Type.KeyPress,
+                QtCore.Qt.Key.Key_Control,
+                QtCore.Qt.KeyboardModifier.ControlModifier,
+            ),
+            QtGui.QKeyEvent(
+                QtCore.QEvent.Type.KeyPress,
+                QtCore.Qt.Key.Key_C,
+                QtCore.Qt.KeyboardModifier.ControlModifier,
+                "c",
+            ),
+            QtGui.QKeyEvent(
+                QtCore.QEvent.Type.KeyRelease,
+                QtCore.Qt.Key.Key_C,
+                QtCore.Qt.KeyboardModifier.ControlModifier,
+                "c",
+            ),
+            QtGui.QKeyEvent(
+                QtCore.QEvent.Type.KeyRelease,
+                QtCore.Qt.Key.Key_Control,
+                QtCore.Qt.KeyboardModifier.NoModifier,
+            ),
+        )
+        for event in events:
+            self.assertTrue(self.window.eventFilter(self.window, event))
+        self.window._stop_recording()
+
+        recorded = self.window._get_macro_events_from_table()
+        self.assertEqual(
+            [(event.keycode, event.is_down, event.is_modifier)
+             for event in recorded],
+            [
+                (vp.MACRO_MODIFIER_CODES["Left Ctrl"], True, True),
+                (vp.HID_KEY_USAGE["C"], True, False),
+                (vp.HID_KEY_USAGE["C"], False, False),
+                (vp.MACRO_MODIFIER_CODES["Left Ctrl"], False, True),
+            ],
+        )
+        self.assertIn("[Left Ctrl+C]", self.window.macro_preview_label.text())
+        self.assertNotIn("still pressed", self.window.macro_preview_label.text())
+
+    def test_alt_meta_and_shift_are_recorded_as_modifier_events(self):
+        cases = (
+            (QtCore.Qt.Key.Key_Alt, "Left Alt"),
+            (QtCore.Qt.Key.Key_Meta, "GUI"),
+            (QtCore.Qt.Key.Key_Shift, "Left Shift"),
+        )
+        for qt_key, expected_name in cases:
+            key_event = QtGui.QKeyEvent(
+                QtCore.QEvent.Type.KeyPress,
+                qt_key,
+                QtCore.Qt.KeyboardModifier.NoModifier,
+            )
+            self.assertEqual(
+                self.window._qt_key_to_macro_modifier(key_event),
+                (expected_name, vp.MACRO_MODIFIER_CODES[expected_name]),
+            )
+
+    def test_native_right_modifier_metadata_selects_right_code(self):
+        right_ctrl = QtGui.QKeyEvent(
+            QtCore.QEvent.Type.KeyPress,
+            QtCore.Qt.Key.Key_Control,
+            QtCore.Qt.KeyboardModifier.ControlModifier,
+            105,
+            0xFFE4,
+            0,
+        )
+        self.assertEqual(
+            self.window._qt_key_to_macro_modifier(right_ctrl),
+            ("Right Ctrl", vp.MACRO_MODIFIER_CODES["Right Ctrl"]),
+        )
 
     def test_press_only_is_boolean_and_warns_when_unreleased(self):
         self.window.add_action_combo.setCurrentIndex(

--- a/venus_gui.py
+++ b/venus_gui.py
@@ -104,22 +104,68 @@ class KeyCaptureEdit(QtWidgets.QLineEdit):
     def isEmpty(self) -> bool:
         return not self._hid_name
 
-    # X11 native scan codes for right-side modifiers (left-side handled by _QT_TO_HID)
+    # Qt reports a generic Key_Shift/Control/Alt/Meta value for both sides.
+    # X11/XKB usually exposes evdev + 8 here, while native Wayland backends may
+    # expose the evdev code itself.  Only consult these maps for an actual Qt
+    # modifier key, so overlapping ordinary-key scan codes cannot be mistaken
+    # for modifiers.
     _RIGHT_MOD_SCANCODES = {
         62: "Right Shift",   # X11 keycode for Right Shift
         105: "Right Ctrl",   # X11 keycode for Right Ctrl
         108: "Right Alt",    # X11 keycode for Right Alt
         134: "Right GUI",    # X11 keycode for Right Super
+        54: "Right Shift",   # Linux evdev KEY_RIGHTSHIFT
+        97: "Right Ctrl",    # Linux evdev KEY_RIGHTCTRL
+        100: "Right Alt",    # Linux evdev KEY_RIGHTALT
+        126: "Right GUI",    # Linux evdev KEY_RIGHTMETA
     }
+    _RIGHT_MOD_NATIVE_KEYS = {
+        0xFFE2: "Right Shift",  # XK_Shift_R
+        0xFFE4: "Right Ctrl",   # XK_Control_R
+        0xFFEA: "Right Alt",    # XK_Alt_R
+        0xFFEC: "Right GUI",    # XK_Super_R
+    }
+
+    @classmethod
+    def modifier_name_for_event(cls, event: QtGui.QKeyEvent) -> str | None:
+        """Return a side-aware modifier name for a Qt key event."""
+        key = event.key()
+        altgr_key = getattr(QtCore.Qt.Key, "Key_AltGr", None)
+        modifier_defaults = {
+            QtCore.Qt.Key.Key_Shift: "Left Shift",
+            QtCore.Qt.Key.Key_Control: "Left Ctrl",
+            QtCore.Qt.Key.Key_Alt: "Left Alt",
+            QtCore.Qt.Key.Key_Meta: "Left GUI",
+        }
+        if altgr_key is not None:
+            modifier_defaults[altgr_key] = "Right Alt"
+        if key not in modifier_defaults:
+            return None
+
+        native_name = cls._RIGHT_MOD_NATIVE_KEYS.get(event.nativeVirtualKey())
+        scan_name = cls._RIGHT_MOD_SCANCODES.get(event.nativeScanCode())
+        if altgr_key is not None and key == altgr_key:
+            expected_family = "Alt"
+        else:
+            expected_family = {
+                QtCore.Qt.Key.Key_Shift: "Shift",
+                QtCore.Qt.Key.Key_Control: "Ctrl",
+                QtCore.Qt.Key.Key_Alt: "Alt",
+                QtCore.Qt.Key.Key_Meta: "GUI",
+            }[key]
+        for candidate in (native_name, scan_name):
+            if candidate and expected_family in candidate:
+                return candidate
+        return modifier_defaults[key]
 
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         key = event.key()
         mods = event.modifiers()
 
-        # Check for right-side modifiers via native scan code
-        scan = event.nativeScanCode()
-        if scan in self._RIGHT_MOD_SCANCODES:
-            name = self._RIGHT_MOD_SCANCODES[scan]
+        # Check for right-side modifiers via native scan/virtual-key metadata.
+        modifier_name = self.modifier_name_for_event(event)
+        if modifier_name:
+            name = modifier_name
         elif bool(mods & QtCore.Qt.KeyboardModifier.KeypadModifier) and key in self._KEYPAD_MAP:
             name = self._KEYPAD_MAP[key]
         else:
@@ -1063,8 +1109,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.add_key_combo.addItem("Mouse: Middle Button", ("mouse", 0x04))
         self.add_key_combo.addItem("Mouse: Back Button", ("mouse", 0x08))
         self.add_key_combo.addItem("Mouse: Forward Button", ("mouse", 0x10))
-        self.add_key_combo.addItem(
-            "Modifier: Shift", ("modifier", vp.MACRO_SHIFT_CODE))
+        for modifier_name, modifier_code in vp.MACRO_MODIFIER_CODES.items():
+            self.add_key_combo.addItem(
+                f"Modifier: {modifier_name}",
+                ("modifier", modifier_code),
+            )
         self.add_key_combo.insertSeparator(self.add_key_combo.count())
         manual_keys = sorted(
             ((name, code) for code, name in self.HID_USAGE_TO_NAME.items()
@@ -1300,26 +1349,26 @@ class MainWindow(QtWidgets.QMainWindow):
                 key_text = key_event.text().upper()
                 qt_key = key_event.key()
 
-                unsupported_modifiers = (
-                    QtCore.Qt.KeyboardModifier.ControlModifier |
-                    QtCore.Qt.KeyboardModifier.AltModifier |
-                    QtCore.Qt.KeyboardModifier.MetaModifier
-                )
-                if (key_event.modifiers() & unsupported_modifiers or
-                        qt_key in (
-                            QtCore.Qt.Key.Key_Control,
-                            QtCore.Qt.Key.Key_Alt,
-                            QtCore.Qt.Key.Key_Meta,
-                        )):
-                    self._set_macro_builder_status(
-                        "Recording skipped a Ctrl/Alt/Meta combination: only "
-                        "the capture-confirmed Shift modifier is available in "
-                        "this macro format.", error=True)
-                    return True
+                modifier = self._qt_key_to_macro_modifier(key_event)
+                if modifier is not None:
+                    modifier_name, keycode = modifier
+                    key_name = f"Modifier: {modifier_name}"
+                    is_modifier = True
+                    event_type = "modifier"
+                else:
+                    # Map the non-modifier Qt key to a keyboard HID usage.
+                    key_name = self._qt_key_to_name(qt_key, key_text)
+                    if not key_name or key_name not in vp.HID_KEY_USAGE:
+                        self._set_macro_builder_status(
+                            f"Recording skipped unsupported key 0x{qt_key:X}.",
+                            error=True,
+                        )
+                        return True
+                    keycode = vp.HID_KEY_USAGE[key_name]
+                    is_modifier = False
+                    event_type = "keyboard"
 
-                # Map Qt key to HID key name
-                key_name = self._qt_key_to_name(qt_key, key_text)
-                if key_name and key_name in vp.HID_KEY_USAGE:
+                if key_name:
                     current_time = time.time() * 1000  # ms
                     if (self._last_key_time > 0 and
                             self.macro_event_table.rowCount()):
@@ -1335,13 +1384,10 @@ class MainWindow(QtWidgets.QMainWindow):
                             delay_widget.setValue(previous_delay)
 
                     is_down = event.type() == QtCore.QEvent.Type.KeyPress
-                    is_modifier = key_name == "Shift"
-                    keycode = (vp.MACRO_SHIFT_CODE if is_modifier
-                               else vp.HID_KEY_USAGE[key_name])
                     added = self._add_event_to_table(
                         key_name, is_down, vp.MACRO_MIN_DELAY_MS,
                         is_modifier=is_modifier,
-                        event_type="modifier" if is_modifier else "keyboard",
+                        event_type=event_type,
                         keycode=keycode,
                     )
                     if not added:
@@ -1364,9 +1410,21 @@ class MainWindow(QtWidgets.QMainWindow):
         # Handle number keys
         if len(key_text) == 1 and key_text.isdigit():
             return key_text
-        if qt_key == QtCore.Qt.Key.Key_Shift:
-            return "Shift"
         return KeyCaptureEdit._QT_TO_HID.get(qt_key)
+
+    def _qt_key_to_macro_modifier(
+            self, key_event: QtGui.QKeyEvent) -> tuple[str, int] | None:
+        """Map a Qt modifier event to the vendor's stored-macro code."""
+        modifier_name = KeyCaptureEdit.modifier_name_for_event(key_event)
+        if modifier_name is None:
+            return None
+        # The vendor converter collapses left/right GUI keys to one byte.
+        if modifier_name in ("Left GUI", "Right GUI"):
+            modifier_name = "GUI"
+        keycode = vp.MACRO_MODIFIER_CODES.get(modifier_name)
+        if keycode is None:
+            return None
+        return modifier_name, keycode
 
     def _set_macro_builder_status(self, message: str,
                                   error: bool = False) -> None:
@@ -1652,7 +1710,7 @@ class MainWindow(QtWidgets.QMainWindow):
         total_delay = sum(event.delay_ms for event in events)
         output: list[str] = []
         pressed: set[tuple[str, int]] = set()
-        shift_active = False
+        active_modifiers: set[int] = set()
 
         for event in events:
             event_type = "modifier" if event.is_modifier else event.event_type
@@ -1662,8 +1720,11 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 pressed.discard(identity)
 
-            if event_type == "modifier" and event.keycode == vp.MACRO_SHIFT_CODE:
-                shift_active = event.is_down
+            if event_type == "modifier":
+                if event.is_down:
+                    active_modifiers.add(event.keycode)
+                else:
+                    active_modifiers.discard(event.keycode)
             elif event_type == "mouse" and event.is_down:
                 mouse_names = {
                     0x01: "Left click", 0x02: "Right click",
@@ -1672,14 +1733,28 @@ class MainWindow(QtWidgets.QMainWindow):
                 }
                 output.append(f"[{mouse_names.get(event.keycode, 'Mouse click')}]")
             elif event_type == "keyboard" and event.is_down:
-                character = vp.ASCII_FROM_HID.get(
-                    (event.keycode, shift_active))
-                if character is not None:
-                    output.append(character)
-                else:
+                non_text_modifiers = active_modifiers.intersection(
+                    vp.MACRO_NON_TEXT_MODIFIER_CODES)
+                if non_text_modifiers:
+                    modifier_labels = "+".join(
+                        vp.MACRO_MODIFIER_NAMES.get(code, f"0x{code:02X}")
+                        for code in sorted(active_modifiers)
+                    )
                     name = self.HID_USAGE_TO_NAME.get(
                         event.keycode, f"0x{event.keycode:02X}")
-                    output.append(f"[{name}]")
+                    output.append(f"[{modifier_labels}+{name}]")
+                else:
+                    shift_active = bool(
+                        active_modifiers.intersection(
+                            vp.MACRO_SHIFT_CODES))
+                    character = vp.ASCII_FROM_HID.get(
+                        (event.keycode, shift_active))
+                    if character is not None:
+                        output.append(character)
+                    else:
+                        name = self.HID_USAGE_TO_NAME.get(
+                            event.keycode, f"0x{event.keycode:02X}")
+                        output.append(f"[{name}]")
 
         rendered = json.dumps("".join(output), ensure_ascii=False)
         warning = f" · ⚠ {len(pressed)} still pressed" if pressed else ""
@@ -4087,8 +4162,9 @@ class MainWindow(QtWidgets.QMainWindow):
                                              update_preview=False)
                 else:
                     if is_modifier:
+                        modifier_name = vp.MACRO_MODIFIER_NAMES.get(keycode)
                         key_name = (
-                            "Modifier: Shift" if keycode == vp.MACRO_SHIFT_CODE
+                            f"Modifier: {modifier_name}" if modifier_name
                             else f"Modifier 0x{keycode:02X}")
                     else:
                         key_name = self.HID_USAGE_TO_NAME.get(
@@ -4143,7 +4219,10 @@ class MainWindow(QtWidgets.QMainWindow):
         for event in events:
             event_type = "modifier" if event.is_modifier else event.event_type
             if event_type == "modifier":
-                key_name = "Modifier: Shift"
+                modifier_name = vp.MACRO_MODIFIER_NAMES.get(event.keycode)
+                key_name = (
+                    f"Modifier: {modifier_name}" if modifier_name
+                    else f"Modifier 0x{event.keycode:02X}")
             else:
                 key_name = self.HID_USAGE_TO_NAME.get(
                     event.keycode, f"Key 0x{event.keycode:02X}")

--- a/venus_protocol.py
+++ b/venus_protocol.py
@@ -446,7 +446,34 @@ MACRO_REPEAT_TOGGLE = 0xFF   # Toggle on/off
 MACRO_SLOT_SIZE = 0x180
 MACRO_HEADER_SIZE = 0x20
 MACRO_TERMINATOR_SIZE = 4
-MACRO_SHIFT_CODE = 0x20
+
+# Stored macros do not use the HID report modifier byte used by direct button
+# bindings.  These are the one-byte codes emitted by the vendor driver's
+# StMacro_To_HdMacro converter.  Left/right GUI collapse to the same 0x08 code.
+MACRO_MODIFIER_CODES = {
+    "Left Ctrl": 0x01,
+    "Left Shift": 0x02,
+    "Left Alt": 0x04,
+    "GUI": 0x08,
+    "Right Ctrl": 0x10,
+    "Right Shift": 0x20,
+    "Right Alt": 0x40,
+}
+MACRO_MODIFIER_NAMES = {
+    code: name for name, code in MACRO_MODIFIER_CODES.items()
+}
+MACRO_SHIFT_CODES = frozenset((
+    MACRO_MODIFIER_CODES["Left Shift"],
+    MACRO_MODIFIER_CODES["Right Shift"],
+))
+MACRO_NON_TEXT_MODIFIER_CODES = frozenset(
+    code for code in MACRO_MODIFIER_NAMES if code not in MACRO_SHIFT_CODES
+)
+
+# Backward-compatible name used by the text builder.  Existing captures of
+# shifted text use the vendor's right-Shift code, so keep generating that exact
+# byte while accepting both left and right Shift everywhere else.
+MACRO_SHIFT_CODE = MACRO_MODIFIER_CODES["Right Shift"]
 MACRO_MIN_DELAY_MS = 3
 MACRO_MAX_EVENTS = (
     MACRO_SLOT_SIZE - MACRO_HEADER_SIZE - MACRO_TERMINATOR_SIZE
@@ -872,7 +899,7 @@ class MacroEvent:
         
         Status codes:
         - 0x81 = Key Down, 0x41 = Key Up (regular keys)
-        - 0x80 = Modifier Down, 0x40 = Modifier Up (Shift, Ctrl, Alt)
+        - 0x80 = Modifier Down, 0x40 = Modifier Up
         - 0x84 = Mouse Down, 0x44 = Mouse Up
 
         The vendor converter accepts event classes 0, 1, and 4 only.  Relative
@@ -980,13 +1007,20 @@ def build_text_macro_events(
 
 def macro_events_to_text(events: Iterable[MacroEvent]) -> str:
     """Best-effort text preview for keyboard events in a hardware macro."""
-    shift_active = False
+    active_modifiers: set[int] = set()
     characters: list[str] = []
     for event in events:
         event_type = "modifier" if event.is_modifier else event.event_type
-        if event_type == "modifier" and event.keycode == MACRO_SHIFT_CODE:
-            shift_active = event.is_down
-        elif event_type == "keyboard" and event.is_down:
+        if event_type == "modifier":
+            if event.is_down:
+                active_modifiers.add(event.keycode)
+            else:
+                active_modifiers.discard(event.keycode)
+        elif (event_type == "keyboard" and event.is_down and
+              not active_modifiers.intersection(
+                  MACRO_NON_TEXT_MODIFIER_CODES)):
+            shift_active = bool(
+                active_modifiers.intersection(MACRO_SHIFT_CODES))
             character = ASCII_FROM_HID.get((event.keycode, shift_active))
             if character is not None:
                 characters.append(character)


### PR DESCRIPTION
## What changed

- implement the vendor-confirmed stored-macro codes for left/right Ctrl, Shift, and Alt plus GUI/Super
- record modifier press/release events instead of discarding shortcuts
- expose every supported modifier in the manual macro builder
- preserve modifiers while loading slots and render shortcut combinations in the preview
- document the distinct macro modifier encoding and update the README/editor guide

## Why

The recorder previously allowed only the already-observed Shift code and silently skipped Ctrl, Alt, and Meta combinations. Reverse engineering both conversion directions in the Windows driver established the complete macro modifier map, so the editor can now encode those events without guessing.

## User impact

Hardware macros can now preserve combinations such as Ctrl+C and Ctrl+Alt+Delete, including left/right identity for Ctrl, Shift, and Alt when Qt supplies it. GUI/Super uses the single shared code exposed by the firmware.

## Validation

- `/usr/bin/python -m unittest tests.test_areson_protocol_offline tests.test_holtek_protocol_offline tests.test_battery_led_gui tests.test_macro_editor tests.test_protocol tests.test_rgb tests.test_staging tests.test_atomic_controller tests.test_error_recovery`
- 58 tests passed
- `git diff --check`