### PR TITLE
Fix AppImage release validation

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -88,7 +88,6 @@ jobs:
         run: |
           docker run --rm -v "$PWD/dist:/packages:ro" debian:13-slim sh -lc '
             apt-get update -qq && apt-get install -y -qq libgl1 >/dev/null &&
-            chmod +x /packages/*.AppImage
             set +e
             QT_QPA_PLATFORM=offscreen APPIMAGE_EXTRACT_AND_RUN=1 timeout 8 /packages/*.AppImage
             status=$?


### PR DESCRIPTION
The AppImage smoke test mounted release assets read-only, then attempted to chmod the already-executable image. Remove that invalid mutation so the test reaches the actual headless launch. The release asset remains mounted read-only.