### PR TITLE
Fix portable package validation

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Smoke-test AppImage without host Python or Qt packages
         run: |
           docker run --rm -v "$PWD/dist:/packages:ro" debian:13-slim sh -lc '
-            apt-get update -qq && apt-get install -y -qq libgl1 >/dev/null &&
+            apt-get update -qq && apt-get install -y -qq libegl1 libgl1 >/dev/null &&
             set +e
             QT_QPA_PLATFORM=offscreen APPIMAGE_EXTRACT_AND_RUN=1 timeout 8 /packages/*.AppImage
             status=$?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download the package for your distribution from the
 | Fedora 43+ | `.rpm` | `sudo dnf install ./venusprolinux-*.rpm` | `python3`, `python3-pyqt6`, `python3-hidapi` |
 | Arch Linux | `.pkg.tar.zst` | `sudo pacman -U ./venusprolinux-*.pkg.tar.zst` | `python`, `python-pyqt6`, `python-hidapi` |
 | Cross-distribution | `.flatpak` | `flatpak install --user ./VenusProLinux-*.flatpak` | Bundled in the Flatpak |
-| Cross-distribution x86_64 | `.AppImage` | `chmod +x ./VenusProLinux-*.AppImage && ./VenusProLinux-*.AppImage` | Python, PyQt6, and hidapi bundled; system `libGL` |
+| Cross-distribution x86_64 | `.AppImage` | `chmod +x ./VenusProLinux-*.AppImage && ./VenusProLinux-*.AppImage` | Python, PyQt6, and hidapi bundled; system `libGL`/`libEGL` |
 
 The native packages install the udev access rule automatically. Flatpak and
 AppImage cannot install host udev rules. Download and install the reviewed

--- a/packaging/flatpak/build-flatpak.sh
+++ b/packaging/flatpak/build-flatpak.sh
@@ -31,7 +31,7 @@ flatpak install --user --noninteractive -y flathub \
 
 BUILD_ROOT="$(mktemp -d -t venusprolinux-flatpak.XXXXXX)"
 trap 'rm -rf "${BUILD_ROOT}"' EXIT
-flatpak-builder --user --force-clean --share=network \
+flatpak-builder --user --force-clean \
     --install-deps-from=flathub --repo="${BUILD_ROOT}/repo" \
     "${BUILD_ROOT}/build" \
     "${SCRIPT_DIR}/${VENUS_APP_ID}.yml"

--- a/packaging/flatpak/com.github.es00bac.venusprolinux.yml
+++ b/packaging/flatpak/com.github.es00bac.venusprolinux.yml
@@ -16,6 +16,9 @@ finish-args:
 modules:
   - name: venusprolinux
     buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
     build-commands:
       - python3 -m pip install --no-cache-dir --prefix=/app PyQt6==6.11.0 PyQt6-Qt6==6.11.1 PyQt6-sip==13.12.0 hidapi==0.15.0
       - install -d /app/share/venusprolinux /app/bin /app/share/applications /app/share/icons/hicolor/1024x1024/apps /app/share/metainfo


### PR DESCRIPTION
Move Flatpak network sharing to the module's build sandbox, where flatpak-builder supports it, while keeping runtime networking disabled. Also install the standard host EGL loader in the minimal AppImage smoke-test container and document the AppImage's GL/EGL system requirement.