### PR TITLE
Fix Flatpak finish permissions and branch

### DIFF
--- a/packaging/flatpak/build-flatpak.sh
+++ b/packaging/flatpak/build-flatpak.sh
@@ -32,6 +32,7 @@ flatpak install --user --noninteractive -y flathub \
 BUILD_ROOT="$(mktemp -d -t venusprolinux-flatpak.XXXXXX)"
 trap 'rm -rf "${BUILD_ROOT}"' EXIT
 flatpak-builder --user --force-clean --state-dir="${BUILD_ROOT}/state" \
+    --default-branch=stable \
     --install-deps-from=flathub --repo="${BUILD_ROOT}/repo" \
     "${BUILD_ROOT}/build" \
     "${SCRIPT_DIR}/${VENUS_APP_ID}.yml"

--- a/packaging/flatpak/com.github.es00bac.venusprolinux.yml
+++ b/packaging/flatpak/com.github.es00bac.venusprolinux.yml
@@ -10,7 +10,6 @@ finish-args:
   - --socket=wayland
   - --device=all
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.StatusNotifierItem-*
   - --env=VENUSPROLINUX_PREFIX=/app
 
 modules:


### PR DESCRIPTION
Fixes the validation failure caused by an invalid StatusNotifierItem D-Bus wildcard while retaining access to the tray watcher. Also writes the OSTree ref to the stable branch consumed by the single-file bundle step.\n\nValidation: bash syntax and git diff checks pass; full clean-run Flatpak validation will run again after merge.