### PR TITLE
Avoid redundant Debian runner bootstrap

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Build Debian and Ubuntu package
         run: |
           VERSION="${RELEASE_VERSION#v}"
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq dpkg-dev
+          command -v dpkg-deb
           bash packaging/deb/build-deb.sh "$VERSION"
       - name: Verify Debian dependencies and imports
         run: |


### PR DESCRIPTION
The Ubuntu runner already provides dpkg-deb, which is the only native tool needed to assemble the package. Avoid a redundant host apt update that can stall; the following clean Debian 13 container step still installs the generated package and verifies its declared runtime imports.